### PR TITLE
Prevent endless looping on bogus stream length and other EOFs

### DIFF
--- a/benchmarks/converter.py
+++ b/benchmarks/converter.py
@@ -22,12 +22,23 @@ PASSWORDS = {
     "aes-256-m.pdf": ["foo"],
     "aes-256-r6.pdf": ["usersecret", "ownersecret"],
 }
+PDFMINER_BUGS = {
+    "issue-449-vertical.pdf",
+    "issue_495_pdfobjref.pdf",
+    "issue-1008-inline-ascii85.pdf",
+    "rotated.pdf",
+}
+XFAILS = {
+    "bogus-stream-length.pdf",
+}
 
 
 def benchmark_one_pdf(path: Path):
     """Open one of the documents"""
     import playa
 
+    if path.name in PDFMINER_BUGS or path.name in XFAILS:
+        return
     passwords = PASSWORDS.get(path.name, [""])
     for password in passwords:
         LOG.info("Reading %s", path)
@@ -40,6 +51,8 @@ def benchmark_one_lazy(path: Path):
     """Open one of the documents"""
     import playa
 
+    if path.name in PDFMINER_BUGS or path.name in XFAILS:
+        return
     passwords = PASSWORDS.get(path.name, [""])
     for password in passwords:
         LOG.info("Reading %s", path)
@@ -59,6 +72,8 @@ def benchmark_one_pdfminer(path: Path):
     from pdfminer.pdfpage import PDFPage
     from pdfminer.pdfparser import PDFParser
 
+    if path.name in PDFMINER_BUGS or path.name in XFAILS:
+        return
     passwords = PASSWORDS.get(path.name, [""])
     for password in passwords:
         with open(path, "rb") as infh:

--- a/playa/document.py
+++ b/playa/document.py
@@ -132,6 +132,8 @@ class XRefTable:
     def _load(self, parser: ObjectParser) -> None:
         while True:
             pos, line = parser.nextline()
+            if line == b"":
+                break
             line = line.strip()
             if not line:
                 continue
@@ -149,6 +151,8 @@ class XRefTable:
                 raise ValueError(error_msg)
             for objid in range(start, start + nobjs):
                 _, line = parser.nextline()
+                if line == b"":
+                    break
                 line = line.strip()
                 f = line.split(b" ")
                 if len(f) != 3:

--- a/playa/parser.py
+++ b/playa/parser.py
@@ -623,10 +623,11 @@ class IndirectObjectParser:
                 linepos, line = self._parser.nextline()
                 log.debug("After stream data: %r %r", linepos, line)
                 if self.strict:
-                    log.warning(
-                        "Expected a newline between end of stream and 'endstream', got %r",
-                        line,
-                    )
+                     # In reality there usually is no end-of-line
+                     # marker.  We will nonetheless warn if there's
+                     # something other than 'endstream'.
+                    if line not in (b"\n", b"\r\n", b"endstream\n", b"endstream\r\n"):
+                        log.warning("Expected newline or 'endstream', got %r", line)
                 else:
                     # Reuse that line and read more if necessary
                     while True:
@@ -640,6 +641,9 @@ class IndirectObjectParser:
                         data += line
                         linepos, line = self._parser.nextline()
                         log.debug("After stream data: %r %r", linepos, line)
+                        if line == b"":  # Means EOF
+                            log.warning("Incorrect legnth for stream, no 'endstream' found")
+                            break
                 doc = None if self.doc is None else self.doc()
                 stream = ContentStream(
                     dic, bytes(data), None if doc is None else doc.decipher

--- a/samples/bogus-stream-length.pdf
+++ b/samples/bogus-stream-length.pdf
@@ -1,0 +1,64 @@
+%PDF-1.4
+1 0 obj
+<<
+ /Type /Catalog
+ /Outlines 2 0 R
+ /Pages 3 0 R
+>>
+endobj
+2 0 obj
+<<
+ /Type /Outlines
+ /Count 0
+>>
+endobj
+3 0 obj
+<<
+ /Type /Pages
+ /Kids [ 4 0 R ]
+ /Count 1
+>>
+endobj
+4 0 obj
+<<
+ /Type /Page
+ /Parent 3 0 R
+ /MediaBox [ 0 0 300 300 ]
+ /Contents 5 0 R
+ /Resources <<
+  /ProcSet 6 0 R
+  /Font << /F1 7 0 R >>
+ >>
+>>
+endobj
+5 0 obj
+<< /Length 73 >>
+stream
+BT
+/F1 24 Tf
+100 100 Td
+36 TL
+(HELLO) Tj
+(WORLD) '
+ET
+endstream
+endobj
+6 0 obj
+[ /PDF /Text ]
+endobj
+7 0 obj
+<<
+ /Type /Font
+ /Subtype /Type1
+ /Name /F1
+ /BaseFont /Helvetica
+ /Encoding /MacRomanEncoding
+>>
+endobj
+
+trailer 
+<<
+ /Size 8
+ /Root 1 0 R
+>>
+%%EOF

--- a/samples/rotated.pdf
+++ b/samples/rotated.pdf
@@ -1,0 +1,64 @@
+%PDF-1.4
+1 0 obj
+<<
+ /Type /Catalog
+ /Outlines 2 0 R
+ /Pages 3 0 R
+>>
+endobj
+2 0 obj
+<<
+ /Type /Outlines
+ /Count 0
+>>
+endobj
+3 0 obj
+<<
+ /Type /Pages
+ /Kids [ 4 0 R ]
+ /Count 1
+>>
+endobj
+4 0 obj
+<<
+ /Type /Page
+ /Parent 3 0 R
+ /MediaBox [ 0 0 300 300 ]
+ /Contents 5 0 R
+ /Resources <<
+  /ProcSet 6 0 R
+  /Font << /F1 7 0 R >>
+ >>
+>>
+endobj
+5 0 obj
+<< /Length 73 >>
+stream
+BT
+/F1 24 Tf
+0.5 0.86 -0.86 0.5 100 100 Tm
+36 TL
+(HELLO) Tj
+(WORLD) '
+ET
+endstream
+endobj
+6 0 obj
+[ /PDF /Text ]
+endobj
+7 0 obj
+<<
+ /Type /Font
+ /Subtype /Type1
+ /Name /F1
+ /BaseFont /Helvetica
+ /Encoding /MacRomanEncoding
+>>
+endobj
+
+trailer 
+<<
+ /Size 8
+ /Root 1 0 R
+>>
+%%EOF

--- a/tests/test_lazy_api.py
+++ b/tests/test_lazy_api.py
@@ -22,6 +22,9 @@ PASSWORDS = {
     "aes-256-m.pdf": ["foo"],
     "aes-256-r6.pdf": ["usersecret", "ownersecret"],
 }
+XFAILS = {
+    "bogus-stream-length.pdf",
+}
 
 
 def test_content_objects():
@@ -66,6 +69,8 @@ def test_content_objects():
 @pytest.mark.parametrize("path", ALLPDFS, ids=str)
 def test_open_lazy(path: Path) -> None:
     """Open all the documents"""
+    if path.name in XFAILS:
+        pytest.xfail("Intentionally corrupt file: %s" % path.name)
     passwords = PASSWORDS.get(path.name, [""])
     for password in passwords:
         beach = []


### PR DESCRIPTION
Rather serious bug (I believe we call these "security holes") where a stream_length value longer than the actual stream would lead to an endless loop.