### PR TITLE
Require a newline before EI to fix various inline images

### DIFF
--- a/tests/test_object_parser.py
+++ b/tests/test_object_parser.py
@@ -394,7 +394,7 @@ def test_inline_images():
     pos, img = next(parser)
     assert isinstance(img, InlineImage)
     assert img.attrs["Foo"] == b"bar"
-    assert img.rawdata == b"VARIOUS UTTER NONSENSE\n"
+    assert img.rawdata == b"VARIOUS UTTER NONSENSE"
     pos, img = next(parser)
     assert isinstance(img, InlineImage)
     assert img.buffer == b"VARIOUS UTTER NONSENSE"


### PR DESCRIPTION
It might be good to check what other PDF readers do as the spec is super unclear on this and unfortunately some creators do make inline images with "EI" in the data and no filter...

The spec says there *should* be a newline.  Who wrote that?!?