### PR TITLE
Remove most uses of `Typing.cast`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Hatch
         uses: pypa/hatch@install
       - name: Check types with mypy
-        run: hatch run mypy --install-types --non-interactive playa
+        run: hatch run types:check
   test:
     strategy:
       fail-fast: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## PLAYA 0.2.7: Unreleased
-
+- Remove excessive debug logging for a considerable speedup
+- Add rendering matrix to `GlyphObject`
 
 ## PLAYA 0.2.6: 2024-12-30
 - Correct some type annotations (these were not really bugs)

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,4 @@
 ## PLAYA 0.2.x
-- [ ] Add `matrix` to `GlyphObject` as it is often needed
 - [ ] Fix ToUnicode CMaps for CID fonts (file bug against pdfminer)
 - [ ] Optimize text extraction
 - [ ] Support slices and lists in `PageList.__getitem__`

--- a/benchmarks/text.py
+++ b/benchmarks/text.py
@@ -1,0 +1,41 @@
+"""
+Benchmark text extraction on the sample documents.
+"""
+
+import logging
+import time
+from pathlib import Path
+from tests.data import BASEPDFS, PASSWORDS, XFAILS
+from tests.test_open import PDFMINER_BUGS
+
+LOG = logging.getLogger("benchmark-text")
+
+
+def benchmark_chars(path: Path):
+    """Extract just the Unicode characters (a poor substitute for actual
+    text extraction)"""
+    import playa
+
+    if path.name in PDFMINER_BUGS or path.name in XFAILS:
+        return
+    passwords = PASSWORDS.get(path.name, [""])
+    for password in passwords:
+        LOG.info("Reading %s", path)
+        with playa.open(path, password=password) as pdf:
+            for page in pdf.pages:
+                for obj in page.texts:
+                    _ = obj.chars
+
+
+if __name__ == "__main__":
+    # Silence warnings about broken PDFs
+    logging.basicConfig(level=logging.ERROR)
+    niter = 5
+    miner_time = beach_time = lazy_time = 0.0
+    for iter in range(niter + 1):
+        for path in BASEPDFS:
+            start = time.time()
+            benchmark_chars(path)
+            if iter != 0:
+                lazy_time += time.time() - start
+    print("chars took %.2fs / iter" % (lazy_time / niter,))

--- a/playa/ccitt.py
+++ b/playa/ccitt.py
@@ -23,7 +23,6 @@ from typing import (
     Sequence,
     Union,
 )
-from playa.pdftypes import int_value
 
 
 def get_bytes(data: bytes) -> Iterator[int]:
@@ -568,6 +567,7 @@ class CCITTFaxDecoder(CCITTG4Parser):
 
 
 def ccittfaxdecode(data: bytes, params: Dict[str, object]) -> bytes:
+    from playa.pdftypes import int_value
     K = params.get("K")
     if K == -1:
         cols = int_value(params.get("Columns"))

--- a/playa/ccitt.py
+++ b/playa/ccitt.py
@@ -22,8 +22,8 @@ from typing import (
     Optional,
     Sequence,
     Union,
-    cast,
 )
+from playa.pdftypes import int_value
 
 
 def get_bytes(data: bytes) -> Iterator[int]:
@@ -570,9 +570,9 @@ class CCITTFaxDecoder(CCITTG4Parser):
 def ccittfaxdecode(data: bytes, params: Dict[str, object]) -> bytes:
     K = params.get("K")
     if K == -1:
-        cols = cast(int, params.get("Columns"))
-        bytealign = cast(bool, params.get("EncodedByteAlign"))
-        reversed = cast(bool, params.get("BlackIs1"))
+        cols = int_value(params.get("Columns"))
+        bytealign = not not params.get("EncodedByteAlign")
+        reversed = not not params.get("BlackIs1")
         parser = CCITTFaxDecoder(cols, bytealign=bytealign, reversed=reversed)
     else:
         raise ValueError(K)

--- a/playa/cmapdb.py
+++ b/playa/cmapdb.py
@@ -30,7 +30,6 @@ from typing import (
     Tuple,
     TypeAlias,
     Union,
-    cast,
 )
 
 from playa.exceptions import PDFSyntaxError

--- a/playa/cmapdb.py
+++ b/playa/cmapdb.py
@@ -28,7 +28,6 @@ from typing import (
     Optional,
     TextIO,
     Tuple,
-    TypeAlias,
     Union,
 )
 
@@ -69,7 +68,7 @@ class CMapBase:
 
 
 # The CID map is a sort of trie
-CodeToCIDMap: TypeAlias = Dict[int, Union[int, "CodeToCIDMap"]]
+CodeToCIDMap = Dict[int, Union[int, "CodeToCIDMap"]]
 
 
 class CMap(CMapBase):

--- a/playa/cmapdb.py
+++ b/playa/cmapdb.py
@@ -28,6 +28,7 @@ from typing import (
     Optional,
     TextIO,
     Tuple,
+    TypeAlias,
     Union,
     cast,
 )
@@ -68,10 +69,14 @@ class CMapBase:
         raise NotImplementedError
 
 
+# The CID map is a sort of trie
+CodeToCIDMap: TypeAlias = Dict[int, Union[int, "CodeToCIDMap"]]
+
+
 class CMap(CMapBase):
     def __init__(self, **kwargs: Union[str, int]) -> None:
         CMapBase.__init__(self, **kwargs)
-        self.code2cid: Dict[int, object] = {}
+        self.code2cid: CodeToCIDMap = {}
 
     def __repr__(self) -> str:
         return "<CMap: %s>" % self.attrs.get("CMapName")
@@ -79,14 +84,14 @@ class CMap(CMapBase):
     def use_cmap(self, cmap: CMapBase) -> None:
         assert isinstance(cmap, CMap), str(type(cmap))
 
-        def copy(dst: Dict[int, object], src: Dict[int, object]) -> None:
+        def copy(dst: CodeToCIDMap, src: CodeToCIDMap) -> None:
             for k, v in src.items():
-                if isinstance(v, dict):
-                    d: Dict[int, object] = {}
+                if isinstance(v, int):
+                    dst[k] = v
+                else:
+                    d: CodeToCIDMap = {}
                     dst[k] = d
                     copy(d, v)
-                else:
-                    dst[k] = v
 
         copy(self.code2cid, cmap.code2cid)
 
@@ -99,14 +104,14 @@ class CMap(CMapBase):
                     yield x
                     d = self.code2cid
                 else:
-                    d = cast(Dict[int, object], x)
+                    d = x
             else:
                 d = self.code2cid
 
     def dump(
         self,
         out: TextIO = sys.stdout,
-        code2cid: Optional[Dict[int, object]] = None,
+        code2cid: Optional[CodeToCIDMap] = None,
         code: Tuple[int, ...] = (),
     ) -> None:
         if code2cid is None:
@@ -117,7 +122,7 @@ class CMap(CMapBase):
             if isinstance(v, int):
                 out.write("code %r = cid %d\n" % (c, v))
             else:
-                self.dump(out=out, code2cid=cast(Dict[int, object], v), code=c)
+                self.dump(out=out, code2cid=v, code=c)
 
 
 class IdentityCMap(CMapBase):

--- a/playa/encodingdb.py
+++ b/playa/encodingdb.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from typing import Dict, Iterable, Optional, cast
+from typing import Dict, Iterable, Optional
 
 from playa.glyphlist import glyphname2unicode
 from playa.latin_enc import ENCODING
@@ -118,7 +118,7 @@ class EncodingDB:
                     cid = x
                 elif isinstance(x, PSLiteral):
                     try:
-                        cid2unicode[cid] = name2unicode(cast(str, x.name))
+                        cid2unicode[cid] = name2unicode(x.name)
                     except (KeyError, ValueError) as e:
                         log.debug("Failed to get char %r: %s", x, e)
                     cid += 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ testpaths = [ "tests" ]
 extra-dependencies = [ "cryptography", "pdfminer.six", "pandas", "polars-lts-cpu" ]
 
 [tool.hatch.envs.default]
-dependencies = [ "cryptography", "pytest", "mypy", "pdfminer.six", "pandas", "polars-lts-cpu" ]
+dependencies = [ "cryptography", "pytest", "pdfminer.six", "pandas", "polars-lts-cpu" ]
 
 [tool.hatch.envs.default.scripts]
 bench = [
@@ -90,3 +90,10 @@ dependencies = [
 [tool.hatch.envs.docs.scripts]
 build = "mkdocs build"
 serve = "mkdocs serve"
+
+[tool.hatch.envs.types]
+extra-dependencies = [
+  "mypy>=1.0.0",
+]
+[tool.hatch.envs.types.scripts]
+check = "mypy --install-types --non-interactive {args:playa tests benchmarks}"


### PR DESCRIPTION
Largely unnecessary, though a few of them remain...