### PR TITLE
fix: deprecate layout in CLI right away and do other useful stuff

### DIFF
--- a/playa/cli.py
+++ b/playa/cli.py
@@ -1,24 +1,71 @@
-"""
-Basic CLI for Playa's "eager" API.  Writes CSV to standard output.
+"""PLAYA's CLI, which can get stuff out of a PDF (one PDF) for you.
+
+By default this will just print some hopefully useful metadata about
+all the pages and indirect objects in the PDF, as a JSON dictionary,
+not because we love JSON, but because it's built-in and easy to parse
+and we hate XML a lot more.  This dictionary will always contain the
+following keys (but will probably contain more in the future):
+
+- `pdf_version`: self-explanatory
+- `is_printable`: whether you should be allowed to print this PDF
+- `is_modifiable`: whether you should be allowed to modify this PDF
+- `is_extractable`: whether you should be allowed to extract text from
+    this PDF (LOL)
+- `pages`: list of descriptions of pages, containing:
+  - `objid`: the indirect object ID of the page descriptor
+  - `label`: a (possibly made up) page label
+  - `mediabox`: the boundaries of the page in default user space
+  - `cropbox`: the cropping box in default user space
+  - `rotate`: the rotation of the page in degrees (no radians for you)
+- `objects`: list of all indirect objects (including those in object
+    streams, as well as the object streams themselves), containing:
+  - `objid`: the object number
+  - `genno`: the generation number
+  - `type`: the type of object this is
+  - `repr`: an arbitrary string representation of the object, **do not
+      depend too closely on the contents of this as it will change**
+
+Bucking the trend of the last 20 years towards horribly slow
+Click-addled CLIs with deeply nested subcommands, anything else is
+just a command-line option away.  You may for instance want to decode
+a particular (object, content, whatever) stream:
+
+    playa --stream 123 foo.pdf
+
+Or recursively expand the document catalog into a horrible mess of JSON:
+
+    playa --catalog foo.pdf
+
+This used to extract arbitrary properties of arbitrary graphical objects
+as a CSV, but for that you want PAVÉS now.
+
 """
 
 import argparse
+import json
 import logging
-import csv
 from pathlib import Path
+from typing import Any
 
 import playa
-from playa.pdftypes import ContentStream
+from playa.document import Document
+from playa.pdftypes import ContentStream, ObjRef
 
 
 def make_argparse() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("pdfs", nargs="+", type=Path)
+    parser.add_argument("pdf", type=Path)
     parser.add_argument(
         "-t",
         "--stream",
         type=int,
-        help="Extract the contents of an object or content stream",
+        help="Decode an object or content stream into raw bytes",
+    )
+    parser.add_argument(
+        "-c",
+        "--catalog",
+        action="store_true",
+        help="Recursively expand the document catalog as JSON",
     )
     parser.add_argument(
         "-o",
@@ -28,13 +75,6 @@ def make_argparse() -> argparse.ArgumentParser:
         default="-",
     )
     parser.add_argument(
-        "-s",
-        "--space",
-        help="Coordinate space for output objects",
-        choices=["screen", "page", "default"],
-        default="screen",
-    )
-    parser.add_argument(
         "--debug",
         help="Very verbose debugging output",
         action="store_true",
@@ -42,22 +82,104 @@ def make_argparse() -> argparse.ArgumentParser:
     return parser
 
 
+def extract_stream(doc: Document, args: argparse.Namespace) -> None:
+    """Extract stream data."""
+    stream = doc[args.stream]
+    if not isinstance(stream, ContentStream):
+        raise RuntimeError("Indirect object {args.stream} is not a stream")
+    args.outfile.buffer.write(stream.buffer)
+
+
+def resolve_many(x: object, default: object = None) -> Any:
+    """Resolves many indirect object references inside the given object.
+
+    Because there may be circular references (and in the case of a
+    logical structure tree, there are *always* circular references),
+    we will not `resolve` them `all` as this makes it impossible to
+    print a nice JSON object.  For the moment we simply resolve them
+    all *once*, though better solutions are possible.
+
+    This means, for instance, that your `/ParentTree` will just be a
+    big list of `ObjRef`.
+
+    """
+
+    def resolver(x: object, default: object, danger: set) -> Any:
+        while isinstance(x, ObjRef) and x not in danger:
+            danger.add(x)
+            x = x.resolve(default=default)
+        if isinstance(x, list):
+            x = [resolver(v, default, danger) for v in x]
+        elif isinstance(x, dict):
+            for k, v in x.items():
+                x[k] = resolver(v, default, danger)
+        elif isinstance(x, ContentStream):
+            for k, v in x.attrs.items():
+                x.attrs[k] = resolver(v, default, danger)
+        return x
+
+    return resolver(x, default, set())
+
+
+def extract_catalog(doc: Document, args: argparse.Namespace) -> None:
+    """Extract catalog data."""
+    json.dump(
+        resolve_many(doc.catalog),
+        args.outfile,
+        indent=2,
+        ensure_ascii=False,
+        default=repr,
+    )
+
+
+def extract_metadata(doc: Document, args: argparse.Namespace) -> None:
+    """Extract random metadata."""
+    stuff = {
+        "pdf_version": doc.pdf_version,
+        "is_printable": doc.is_printable,
+        "is_modifiable": doc.is_modifiable,
+        "is_extractable": doc.is_extractable,
+    }
+    pages = []
+    for page in doc.pages:
+        pages.append(
+            {
+                "objid": page.pageid,
+                "label": page.label,
+                "mediabox": page.mediabox,
+                "cropbox": page.cropbox,
+                "rotate": page.rotate,
+            }
+        )
+    stuff["pages"] = pages
+    objects = []
+    for obj in doc.objects:
+        objects.append(
+            {
+                "objid": obj.objid,
+                "genno": obj.genno,
+                "type": type(obj.obj).__name__,
+                "repr": repr(obj.obj),
+            }
+        )
+    stuff["objects"] = objects
+    json.dump(stuff, args.outfile, indent=2, ensure_ascii=False)
+
+
 def main() -> None:
     parser = make_argparse()
     args = parser.parse_args()
     logging.basicConfig(level=logging.DEBUG if args.debug else logging.WARNING)
-    for path in args.pdfs:
-        with playa.open(path, space=args.space) as doc:
+    try:
+        with playa.open(args.pdf, space="default") as doc:
             if args.stream is not None:  # it can't be zero either though
-                stream = doc[args.stream]
-                if not isinstance(stream, ContentStream):
-                    parser.error(f"Indirect object {args.stream} is not a stream")
-                args.outfile.buffer.write(stream.buffer)
+                extract_stream(doc, args)
+            elif args.catalog:
+                extract_catalog(doc, args)
             else:
-                writer = csv.DictWriter(args.outfile, fieldnames=playa.fieldnames)
-                writer.writeheader()
-                for dic in doc.layout:
-                    writer.writerow(dic)
+                extract_metadata(doc, args)
+    except RuntimeError as e:
+        parser.error(f"Something went wrong:\n{e}")
 
 
 if __name__ == "__main__":

--- a/playa/document.py
+++ b/playa/document.py
@@ -942,8 +942,10 @@ class Document:
 
     @property
     def objects(self) -> Iterator[IndirectObject]:
-        """Iterate over all indirect objects (expanding object streams)"""
+        """Iterate over all indirect objects (including, then expanding object
+        streams)"""
         for pos, obj in IndirectObjectParser(self.buffer, self):
+            yield obj
             if (
                 isinstance(obj.obj, ContentStream)
                 and obj.obj.get("Type") is LITERAL_OBJSTM
@@ -951,8 +953,6 @@ class Document:
                 parser = ObjectStreamParser(obj.obj, self)
                 for spos, sobj in parser:
                     yield sobj
-            else:
-                yield (obj)
 
     @property
     def tokens(self) -> Iterator[Token]:

--- a/playa/page.py
+++ b/playa/page.py
@@ -128,7 +128,7 @@ class Page:
       cropbox: the crop rectangle of the page.
       rotate: the page rotation (in degree).
       label: the page's label (typically, the logical page number).
-      page_number: the "physical" page number, indexed from 1.
+      page_idx: 0-based index of the page in the document.
       ctm: coordinate transformation matrix from default user space to
            page's device space
     """

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -69,7 +69,7 @@ def test_object_streams():
     """Test iterating inside object streams."""
     with playa.open(TESTDIR / "simple5.pdf") as doc:
         objs = list(doc.objects)
-        assert len(objs) == 52
+        assert len(objs) == 53
 
 
 @pytest.mark.skipif(not CONTRIB.exists(), reason="contrib samples not present")

--- a/tests/test_pdftypes.py
+++ b/tests/test_pdftypes.py
@@ -4,6 +4,9 @@ Test PDF types and data structures.
 
 from playa.data_structures import NameTree, NumberTree
 from playa.runlength import rldecode
+from playa.pdftypes import ObjRef, resolve1, resolve_all
+
+import weakref
 
 NUMTREE1 = {
     "Kids": [
@@ -81,3 +84,38 @@ def test_name_tree():
 def test_rle():
     large_white_image_encoded = bytes([129, 255] * (3 * 3000 * 4000 // 128))
     _ = rldecode(large_white_image_encoded)
+
+
+def test_resolve_all():
+    """See if `resolve_all` will really `resolve` them `all`."""
+
+    # Use a mock document, it just needs to suppot __getitem__
+    class MockDoc(dict):
+        pass
+
+    mockdoc = MockDoc({42: "hello"})
+    mockdoc[41] = ObjRef(weakref.ref(mockdoc), 42)
+    mockdoc[40] = ObjRef(weakref.ref(mockdoc), 41)
+    assert mockdoc[41].resolve() == "hello"
+    assert resolve1(mockdoc[41]) == "hello"
+    assert mockdoc[40].resolve() == mockdoc[41]
+    assert resolve_all(mockdoc[40]) == "hello"
+    mockdoc[39] = [mockdoc[40], mockdoc[41]]
+    assert resolve_all(mockdoc[39]) == ["hello", "hello"]
+    mockdoc[38] = ["hello", ObjRef(weakref.ref(mockdoc), 38)]
+    # This resolves the *list*, not the indirect object, so its second
+    # element will get expanded once into a new list.
+    ouf = resolve_all(mockdoc[38])
+    assert ouf[0] == "hello"
+    assert ouf[1][1] is mockdoc[38]
+    # Whereas in this case we are expanding the reference itself.
+    fou = resolve_all(mockdoc[38][1])
+    assert fou[1] is mockdoc[38]
+    # Likewise here, we have to dig a bit to see the circular
+    # reference.  Your best option is not to use resolve_all ;-)
+    mockdoc[30] = ["hello", ObjRef(weakref.ref(mockdoc), 31)]
+    mockdoc[31] = ["hello", ObjRef(weakref.ref(mockdoc), 30)]
+    bof = resolve_all(mockdoc[30])
+    assert bof[1][1][1] is mockdoc[31]
+    fob = resolve_all(mockdoc[30][1])
+    assert fob[1][1] is mockdoc[31]


### PR DESCRIPTION
It was a definite problem that the CLI relied on the deprecated `layout` stuff.  Just so nobody gets any ideas here is a breaking change (sorry not sorry)