### PR TITLE
Avoid using (non-serializable) weak references in worker processes

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -21,3 +21,5 @@
         - StructElement
         - StructTree
         inherited_members: true
+
+::: playa.worker

--- a/playa/__init__.py
+++ b/playa/__init__.py
@@ -20,7 +20,7 @@ from multiprocessing.context import BaseContext
 from pathlib import Path
 from typing import Union
 
-from playa.worker import in_worker, _set_document  # noqa: F401
+from playa.worker import _set_document
 from playa.document import Document, LayoutDict, schema as schema  # noqa: F401
 from playa.page import DeviceSpace
 from playa._version import __version__  # noqa: F401

--- a/playa/__init__.py
+++ b/playa/__init__.py
@@ -20,7 +20,7 @@ from multiprocessing.context import BaseContext
 from pathlib import Path
 from typing import Union
 
-import playa.document
+from playa.worker import in_worker, _set_document  # noqa: F401
 from playa.document import Document, LayoutDict, schema as schema  # noqa: F401
 from playa.page import DeviceSpace
 from playa._version import __version__  # noqa: F401
@@ -28,8 +28,9 @@ from playa._version import __version__  # noqa: F401
 fieldnames = LayoutDict.__annotations__.keys()
 
 
-def init_worker(path: Path, password: str = "", space: DeviceSpace = "screen") -> None:
-    playa.document.__pdf = open(path, password=password, space=space)
+def _init_worker(path: Path, password: str = "", space: DeviceSpace = "screen") -> None:
+    fp = builtins.open(path, "rb")
+    _set_document(Document(fp, password=password, space=space, init_worker=True))
 
 
 def open(
@@ -61,7 +62,7 @@ def open(
         pdf._pool = ProcessPoolExecutor(
             max_workers=max_workers,
             mp_context=mp_context,
-            initializer=init_worker,  # type: ignore[arg-type]
+            initializer=_init_worker,  # type: ignore[arg-type]
             initargs=(path, password, space),  # type: ignore[arg-type]
         )
     return pdf

--- a/playa/document.py
+++ b/playa/document.py
@@ -833,6 +833,8 @@ class Document:
         init_worker: bool = False,
     ) -> None:
         if init_worker:
+            # Set this **right away** because it is needed to get
+            # indirect object references right.
             _set_document(self)
         self.xrefs: List[XRef] = []
         self.space = space

--- a/playa/document.py
+++ b/playa/document.py
@@ -820,6 +820,7 @@ class Document:
         if self._fp:
             self._fp.close()
             self._fp = None
+        # Shutdown process pool
         if self._pool:
             self._pool.shutdown()
             self._pool = None

--- a/playa/page.py
+++ b/playa/page.py
@@ -6,7 +6,6 @@ import itertools
 import logging
 import re
 import warnings
-import weakref
 from copy import copy
 from dataclasses import dataclass
 from typing import (
@@ -71,7 +70,7 @@ from playa.utils import (
     translate_matrix,
 )
 from playa.structtree import StructTree
-from playa.worker import _deref_document, _ref_document
+from playa.worker import _deref_document, _ref_document, _ref_page, _deref_page, PageRef
 
 if TYPE_CHECKING:
     from playa.document import Document
@@ -223,6 +222,13 @@ class Page:
                 self._contents = contents
             else:
                 self._contents = [contents]
+
+    @property
+    def doc(self) -> Union["Document", None]:
+        """Get associated document if it exists."""
+        if self.docref is None:
+            return None
+        return _deref_document(self.docref)
 
     @property
     def streams(self) -> Iterator[ContentStream]:
@@ -1809,15 +1815,20 @@ class XObjectObject(ContentObject):
     """
 
     xobjid: str
-    page: weakref.ReferenceType
     stream: ContentStream
     resources: Union[None, Dict[str, PDFObject]]
+    _pageref: PageRef
 
     def __contains__(self, name: object) -> bool:
         return name in self.stream
 
     def __getitem__(self, name: str) -> PDFObject:
         return self.stream[name]
+
+    @property
+    def page(self) -> Page:
+        """Get the page (if it exists, raising RuntimeError if not)."""
+        return _deref_page(self._pageref)
 
     @property
     def bbox(self) -> Rect:
@@ -1855,25 +1866,16 @@ class XObjectObject(ContentObject):
             " and will be removed in PLAYA 0.3",
             DeprecationWarning,
         )
-        page = self.page()
-        if page is None:
-            raise RuntimeError("Page no longer exists!")
-        return iter(PageInterpreter(page, [self.stream], self.resources))
+        return iter(PageInterpreter(self.page, [self.stream], self.resources))
 
     @property
     def contents(self) -> Iterator[PDFObject]:
         """Iterator over PDF objects in the content stream."""
-        page = self.page()
-        if page is None:
-            raise RuntimeError("Page no longer exists!")
         for pos, obj in ContentParser([self.stream]):
             yield obj
 
     def __iter__(self) -> Iterator["ContentObject"]:
-        page = self.page()
-        if page is None:
-            raise RuntimeError("Page no longer exists!")
-        return iter(LazyInterpreter(page, [self.stream], self.resources))
+        return iter(LazyInterpreter(self.page, [self.stream], self.resources))
 
 
 @dataclass
@@ -2341,10 +2343,10 @@ class LazyInterpreter(BaseInterpreter):
                 ctm=mult_matrix(matrix, self.ctm),
                 mcstack=self.mcstack,
                 gstate=self.graphicstate,
-                page=weakref.ref(self.page),
                 xobjid=xobjid,
                 stream=xobj,
                 resources=resources,
+                _pageref=_ref_page(self.page),
             )
             # We are *lazy*, so just yield the XObject itself not its contents
             yield xobjobj

--- a/playa/parser.py
+++ b/playa/parser.py
@@ -1,7 +1,6 @@
 import logging
 import mmap
 import re
-import weakref
 from binascii import unhexlify
 from collections import deque
 from typing import (
@@ -16,6 +15,7 @@ from typing import (
     Union,
 )
 
+from playa.worker import _ref_document
 from playa.exceptions import PDFSyntaxError
 from playa.pdftypes import (
     KWD,
@@ -328,7 +328,8 @@ class ObjectParser:
     ) -> None:
         self._lexer = Lexer(data, pos)
         self.stack: List[StackEntry] = []
-        self.doc = None if doc is None else weakref.ref(doc)
+        self.doc = doc
+        self.docref = None if doc is None else _ref_document(doc)
 
     def newstream(self, data: Union[bytes, mmap.mmap]) -> None:
         """Continue parsing from a new data stream."""
@@ -415,7 +416,7 @@ class ObjectParser:
                             "Expected generation and object id in indirect object reference"
                         )
                     objid = int_value(objid)
-                    obj = ObjRef(self.doc, objid)
+                    obj = ObjRef(self.docref, objid)
                     self.stack.append((pos, obj))
             elif token is KEYWORD_BI:
                 if top is None:
@@ -560,7 +561,7 @@ class IndirectObjectParser:
         self._parser = ObjectParser(data, doc)
         self.buffer = data
         self.trailer: List[Tuple[int, Union[PDFObject, ContentStream]]] = []
-        self.doc = None if doc is None else weakref.ref(doc)
+        self.doc = doc
         self.strict = strict
 
     def __iter__(self) -> Iterator[Tuple[int, IndirectObject]]:
@@ -658,9 +659,8 @@ class IndirectObjectParser:
                                 "Incorrect length for stream, no 'endstream' found"
                             )
                             break
-                doc = None if self.doc is None else self.doc()
                 stream = ContentStream(
-                    dic, bytes(data), None if doc is None else doc.decipher
+                    dic, bytes(data), None if self.doc is None else self.doc.decipher
                 )
                 self.trailer.append((pos, stream))
             elif obj is KEYWORD_ENDSTREAM:
@@ -691,7 +691,6 @@ class ObjectStreamParser:
     ) -> None:
         self._parser = ObjectParser(stream.buffer, doc)
         self.buffer = stream.buffer
-        self.doc = None if doc is None else weakref.ref(doc)
         self.nobj = int_value(stream["N"])
         self.first = int_value(stream["First"])
         self.offsets = []

--- a/playa/worker.py
+++ b/playa/worker.py
@@ -1,0 +1,62 @@
+"""Worker subprocess related functions and data."""
+
+import weakref
+from typing import Union, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from playa.document import Document
+    from playa.page import Page
+
+# Type signature of document reference
+DocumentRef = Union[weakref.ReferenceType["Document"], str]
+# Type signature of page reference
+PageRef = Union[weakref.ReferenceType["Page"], int]
+
+# A global PDF object used in worker processes
+__pdf: Union["Document", None] = None
+# Flag used to signal that we should look at the global document
+GLOBAL_DOC = "[citation needed]"
+
+
+def in_worker() -> bool:
+    """Are we currently in a worker process?"""
+    return __pdf is not None
+
+
+def _set_document(doc: "Document") -> None:
+    global __pdf
+    __pdf = doc
+
+
+def _get_document() -> Union["Document", None]:
+    global __pdf
+    return __pdf
+
+
+def _ref_document(doc: "Document") -> DocumentRef:
+    return weakref.ref(doc) if __pdf is None else GLOBAL_DOC
+
+
+def _deref_document(ref: DocumentRef) -> "Document":
+    doc = __pdf
+    if isinstance(ref, weakref.ReferenceType):
+        doc = ref()
+    if doc is None:
+        raise RuntimeError("Document no longer exists (or never existed)!")
+    return doc
+
+
+def _ref_page(page: "Page") -> PageRef:
+    return weakref.ref(page) if __pdf is None else page.page_idx
+
+
+def _deref_page(ref: PageRef) -> "Page":
+    if isinstance(ref, int):
+        if __pdf is None:
+            raise RuntimeError("Not in a worker process, cannot retrieve document!")
+        return __pdf.pages[ref]
+    else:
+        page = ref()
+        if page is None:
+            raise RuntimeError("Page no longer exists!")
+        return page

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -136,6 +136,7 @@ def test_weakrefs() -> None:
     with playa.open(TESTDIR / "simple5.pdf") as doc:
         ref = doc.catalog["Pages"]
     del doc
+    assert ref.doc() is None
     with pytest.raises(RuntimeError):
         _ = ref.resolve()
 

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -9,9 +9,10 @@ from tests.data import TESTDIR, CONTRIB
 
 
 def has_one_true_pdf() -> int:
-    assert playa.document.__pdf is not None
-    assert playa.document.__pdf.space == "default"
-    return len(playa.document.__pdf.pages)
+    doc = playa.worker._get_document()
+    assert doc is not None
+    assert doc.space == "default"
+    return len(doc.pages)
 
 
 def test_open_parallel():


### PR DESCRIPTION
This ... doesn't entirely solve the problem of non-serializability, because we don't have a good way to re-connect them in the, er, "manager" process.  But it at least avoids awful surprises for the moment.