### PR TITLE
Enable resolution of indirect object references when using worker processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,25 @@ You could also just do this for certain pages by subscripting
 some_page_sizes = pdf.pages[2:5].map(get_page_size)
 ```
 
+There are some limitations to this, because it uses `multiprocessing`.
+The function you pass to `map` must be serializable by `pickle`, which
+in practice means that an inner function or lambda generally doesn't
+work.  You can get around this in a very Java-like way by passing a
+callable object that encapsulates the necessary state.  If you wish to
+avoid traumatising readers of your code, then use `functools.partial`
+instead:
+
+```python
+pdf.pages.map(partial(myfunc, arg1=value1, arg2=value2))
+```
+
+Also, any value returned by your function must also be serializable.
+There is a bit of magic that enables this to work for PDF objects
+containing indirect object references, so you should be able to, for
+instance, get the `dests` or `annots` from every page without any
+trouble.  But if you have your own complex objects that you return you
+may encounter problems (or slowness).
+
 ## Dictionary-based API
 
 There used to be a "dictionary-based" API here.  You can now find it

--- a/README.md
+++ b/README.md
@@ -157,6 +157,38 @@ possible piece of information, PLAYA gives you some options here.
 Wherever possible this information can be computed lazily, but this
 involves some more work on the user's part.
 
+## Using multiple CPUs
+
+You may be wondering, what does "Parallel and Lazy" really mean?
+PLAYA allows you to take advantage of multiple CPUs, which can greatly
+speed up some operations on large documents.  This parallelism
+currently operates at the page level since this is the most logical
+way to split up a PDF.  To enable it, pass the `max_workers` argument
+to `playa.open` with the number of cores you wish to use (you can also
+explicitly pass `None` to use the maximum):
+
+```python
+with playa.open(path, max_workers=4) as pdf:
+    ...
+```
+
+Now, you can apply a function across the pages of the PDF in parallel
+using the `map` method of `pdf.pages`, for example:
+
+```python
+def get_page_size(page: Page) -> Tuple[int, int]:
+    return page.width, page.height
+
+page_sizes = pdf.pages.map(get_page_size)
+```
+
+You could also just do this for certain pages by subscripting
+`pdf.pages`:
+
+```python
+some_page_sizes = pdf.pages[2:5].map(get_page_size)
+```
+
 ## Dictionary-based API
 
 There used to be a "dictionary-based" API here.  You can now find it

--- a/playa/__init__.py
+++ b/playa/__init__.py
@@ -19,7 +19,7 @@ from os import PathLike
 from multiprocessing.context import BaseContext
 from typing import Union
 
-from playa.worker import _init_worker, _add_boss
+from playa.worker import _init_worker
 from playa.document import Document, LayoutDict, schema as schema  # noqa: F401
 from playa.page import DeviceSpace
 from playa._version import __version__  # noqa: F401
@@ -59,5 +59,4 @@ def open(
             initializer=_init_worker,  # type: ignore[arg-type]
             initargs=(id(pdf), path, password, space),  # type: ignore[arg-type]
         )
-        _add_boss(pdf)
     return pdf

--- a/playa/__init__.py
+++ b/playa/__init__.py
@@ -17,20 +17,14 @@ import builtins
 from concurrent.futures import ProcessPoolExecutor
 from os import PathLike
 from multiprocessing.context import BaseContext
-from pathlib import Path
 from typing import Union
 
-from playa.worker import _set_document
+from playa.worker import _init_worker, _add_boss
 from playa.document import Document, LayoutDict, schema as schema  # noqa: F401
 from playa.page import DeviceSpace
 from playa._version import __version__  # noqa: F401
 
 fieldnames = LayoutDict.__annotations__.keys()
-
-
-def _init_worker(path: Path, password: str = "", space: DeviceSpace = "screen") -> None:
-    fp = builtins.open(path, "rb")
-    _set_document(Document(fp, password=password, space=space, init_worker=True))
 
 
 def open(
@@ -63,6 +57,7 @@ def open(
             max_workers=max_workers,
             mp_context=mp_context,
             initializer=_init_worker,  # type: ignore[arg-type]
-            initargs=(path, password, space),  # type: ignore[arg-type]
+            initargs=(id(pdf), path, password, space),  # type: ignore[arg-type]
         )
+        _add_boss(pdf)
     return pdf

--- a/playa/document.py
+++ b/playa/document.py
@@ -1395,6 +1395,8 @@ class Document:
 def call_page(func: Callable[[Page], Any], idx: int) -> Any:
     """Call a function on a page in a worker process."""
     doc = _get_document()
+    if doc is None:
+        raise RuntimeError("Document no longer exists (or never existed)!")
     return func(doc.pages[idx])
 
 

--- a/playa/document.py
+++ b/playa/document.py
@@ -85,7 +85,7 @@ from playa.utils import (
     nunpack,
 )
 from playa.structtree import StructTree
-from playa.worker import _set_document, _ref_document, _deref_document, _deref_page
+from playa.worker import _set_document, _ref_document, _deref_document, _deref_page, in_worker
 
 log = logging.getLogger(__name__)
 
@@ -830,12 +830,13 @@ class Document:
         fp: BinaryIO,
         password: str = "",
         space: DeviceSpace = "screen",
-        init_worker: bool = False,
+        _boss_id: int = 0,
     ) -> None:
-        if init_worker:
+        if _boss_id:
             # Set this **right away** because it is needed to get
             # indirect object references right.
-            _set_document(self)
+            _set_document(self, _boss_id)
+            assert in_worker()
         self.xrefs: List[XRef] = []
         self.space = space
         self.info = []

--- a/playa/document.py
+++ b/playa/document.py
@@ -1406,8 +1406,10 @@ class PageList:
     ) -> None:
         self.docref = _ref_document(doc)
         if pages is not None:
-            self._pages = pages
-            self._labels: Dict[str, Page] = {page.label: page for page in pages}
+            self._pages = list(pages)
+            self._labels: Dict[str, Page] = {
+                page.label: page for page in pages if page.label is not None
+            }
         else:
             self._init_pages(doc)
 

--- a/playa/document.py
+++ b/playa/document.py
@@ -85,7 +85,13 @@ from playa.utils import (
     nunpack,
 )
 from playa.structtree import StructTree
-from playa.worker import _set_document, _ref_document, _deref_document, _deref_page, in_worker
+from playa.worker import (
+    _set_document,
+    _ref_document,
+    _deref_document,
+    _get_document,
+    in_worker,
+)
 
 log = logging.getLogger(__name__)
 
@@ -1388,7 +1394,8 @@ class Document:
 
 def call_page(func: Callable[[Page], Any], idx: int) -> Any:
     """Call a function on a page in a worker process."""
-    return func(_deref_page(idx))
+    doc = _get_document()
+    return func(doc.pages[idx])
 
 
 class PageList:

--- a/playa/document.py
+++ b/playa/document.py
@@ -1446,8 +1446,8 @@ class PageList:
             return self._pages[key]
         elif isinstance(key, slice):
             return PageList(_deref_document(self.docref), self._pages[key])
-        elif isinstance(key, tuple):
-            return PageList(_deref_document(self.docref), [self[k] for k in key])
+        elif isinstance(key, (tuple, list)):
+            return PageList(_deref_document(self.docref), (self[k] for k in key))
         else:
             return self._labels[key]
 

--- a/playa/pdftypes.py
+++ b/playa/pdftypes.py
@@ -21,7 +21,7 @@ from playa.ccitt import ccittfaxdecode
 from playa.lzw import lzwdecode
 from playa.runlength import rldecode
 from playa.utils import apply_png_predictor, apply_tiff_predictor
-from playa.worker import DocumentRef, _deref_document
+from playa.worker import DocumentRef, _deref_document, in_worker
 
 logger = logging.getLogger(__name__)
 

--- a/playa/pdftypes.py
+++ b/playa/pdftypes.py
@@ -21,7 +21,7 @@ from playa.ccitt import ccittfaxdecode
 from playa.lzw import lzwdecode
 from playa.runlength import rldecode
 from playa.utils import apply_png_predictor, apply_tiff_predictor
-from playa.worker import DocumentRef, _deref_document, in_worker
+from playa.worker import DocumentRef, _deref_document
 
 logger = logging.getLogger(__name__)
 

--- a/playa/worker.py
+++ b/playa/worker.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from playa.page import Page
 
 # Type signature of document reference
-DocumentRef = Union[weakref.ReferenceType["Document"], int]
+DocumentRef = int
 # Type signature of page reference
 PageRef = Tuple[DocumentRef, int]
 

--- a/playa/worker.py
+++ b/playa/worker.py
@@ -1,21 +1,25 @@
 """Worker subprocess related functions and data."""
 
 import weakref
+from pathlib import Path
 from typing import Union, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from playa.document import Document
+    from playa.document import Document, DeviceSpace
     from playa.page import Page
 
 # Type signature of document reference
-DocumentRef = Union[weakref.ReferenceType["Document"], str]
+DocumentRef = Union[weakref.ReferenceType["Document"], int]
 # Type signature of page reference
 PageRef = Union[weakref.ReferenceType["Page"], int]
 
 # A global PDF object used in worker processes
 __pdf: Union["Document", None] = None
-# Flag used to signal that we should look at the global document
-GLOBAL_DOC = "[citation needed]"
+# Registry of documents which have workers
+__bosses: weakref.WeakValueDictionary[int, "Document"] = weakref.WeakValueDictionary()
+# Numeric id of the document in the boss process (will show up instead
+# of weak references when serialized, gets looked up in _bosses)
+GLOBAL_DOC: int = 0
 
 
 def in_worker() -> bool:
@@ -23,9 +27,29 @@ def in_worker() -> bool:
     return __pdf is not None
 
 
-def _set_document(doc: "Document") -> None:
-    global __pdf
+def _init_worker(
+    boss: int, path: Path, password: str = "", space: "DeviceSpace" = "screen"
+) -> None:
+    from playa.document import Document
+
+    global __pdf, GLOBAL_DOC
+    fp = open(path, "rb")
+    __pdf = Document(fp, password=password, space=space, _boss_id=boss)
+    GLOBAL_DOC = boss
+
+
+def _add_boss(doc: "Document") -> None:
+    """Call this in the parent process."""
+    global __bosses
+    assert not in_worker()
+    __bosses[id(doc)] = doc
+
+
+def _set_document(doc: "Document", boss: int) -> None:
+    """Call this in the worker process."""
+    global __pdf, GLOBAL_DOC
     __pdf = doc
+    GLOBAL_DOC = boss
 
 
 def _get_document() -> Union["Document", None]:
@@ -34,16 +58,26 @@ def _get_document() -> Union["Document", None]:
 
 
 def _ref_document(doc: "Document") -> DocumentRef:
-    return weakref.ref(doc) if __pdf is None else GLOBAL_DOC
+    if in_worker():
+        global GLOBAL_DOC
+        assert GLOBAL_DOC != 0
+        return GLOBAL_DOC
+    else:
+        return weakref.ref(doc)
 
 
 def _deref_document(ref: DocumentRef) -> "Document":
-    doc = __pdf
-    if isinstance(ref, weakref.ReferenceType):
+    if in_worker():
+        return __pdf
+    if isinstance(ref, int):
+        if ref not in __bosses:
+            raise RuntimeError(f"Unknown or deleted document with ID {ref}!")
+        return __bosses[ref]
+    else:
         doc = ref()
-    if doc is None:
-        raise RuntimeError("Document no longer exists (or never existed)!")
-    return doc
+        if doc is None:
+            raise RuntimeError("Document no longer exists (or never existed)!")
+        return doc
 
 
 def _ref_page(page: "Page") -> PageRef:
@@ -58,5 +92,5 @@ def _deref_page(ref: PageRef) -> "Page":
     else:
         page = ref()
         if page is None:
-            raise RuntimeError("Page no longer exists!")
+            raise RuntimeError(f"Page {ref} no longer exists (or never existed)!")
         return page

--- a/playa/worker.py
+++ b/playa/worker.py
@@ -68,20 +68,20 @@ def _ref_document(doc: "Document") -> DocumentRef:
 
 def _deref_document(ref: DocumentRef) -> "Document":
     if in_worker():
-        return __pdf
-    if isinstance(ref, int):
+        doc = __pdf
+    elif isinstance(ref, int):
         if ref not in __bosses:
             raise RuntimeError(f"Unknown or deleted document with ID {ref}!")
-        return __bosses[ref]
+        doc = __bosses[ref]
     else:
         doc = ref()
-        if doc is None:
-            raise RuntimeError("Document no longer exists (or never existed)!")
-        return doc
+    if doc is None:
+        raise RuntimeError("Document no longer exists (or never existed)!")
+    return doc
 
 
 def _ref_page(page: "Page") -> PageRef:
-    return _ref_document(page.doc), page.page_idx
+    return page.docref, page.page_idx
 
 
 def _deref_page(ref: PageRef) -> "Page":

--- a/playa/worker.py
+++ b/playa/worker.py
@@ -2,7 +2,7 @@
 
 import weakref
 from pathlib import Path
-from typing import Union, TYPE_CHECKING
+from typing import Tuple, Union, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from playa.document import Document, DeviceSpace
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 # Type signature of document reference
 DocumentRef = Union[weakref.ReferenceType["Document"], int]
 # Type signature of page reference
-PageRef = Union[weakref.ReferenceType["Page"], int]
+PageRef = Tuple[DocumentRef, int]
 
 # A global PDF object used in worker processes
 __pdf: Union["Document", None] = None
@@ -81,16 +81,10 @@ def _deref_document(ref: DocumentRef) -> "Document":
 
 
 def _ref_page(page: "Page") -> PageRef:
-    return weakref.ref(page) if __pdf is None else page.page_idx
+    return page.doc, page.page_idx
 
 
 def _deref_page(ref: PageRef) -> "Page":
-    if isinstance(ref, int):
-        if __pdf is None:
-            raise RuntimeError("Not in a worker process, cannot retrieve document!")
-        return __pdf.pages[ref]
-    else:
-        page = ref()
-        if page is None:
-            raise RuntimeError(f"Page {ref} no longer exists (or never existed)!")
-        return page
+    docref, idx = ref
+    doc = _deref_document(docref)
+    return doc.pages[idx]

--- a/playa/worker.py
+++ b/playa/worker.py
@@ -81,7 +81,7 @@ def _deref_document(ref: DocumentRef) -> "Document":
 
 
 def _ref_page(page: "Page") -> PageRef:
-    return page.doc, page.page_idx
+    return _ref_document(page.doc), page.page_idx
 
 
 def _deref_page(ref: PageRef) -> "Page":

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -113,6 +113,8 @@ def test_pages():
         assert [p.label for p in twopages] == ["3", "4"]
         threepages = doc.pages["2", 2, 3]
         assert [p.label for p in threepages] == ["2", "3", "4"]
+        threepages = doc.pages[["2", 2, 3]]
+        assert [p.label for p in threepages] == ["2", "3", "4"]
 
 
 @pytest.mark.skipif(not CONTRIB.exists(), reason="contrib samples not present")

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -136,7 +136,6 @@ def test_weakrefs() -> None:
     with playa.open(TESTDIR / "simple5.pdf") as doc:
         ref = doc.catalog["Pages"]
     del doc
-    assert ref.doc() is None
     with pytest.raises(RuntimeError):
         _ = ref.resolve()
 

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -39,7 +39,7 @@ def test_parallel_references():
     with playa.open(
         TESTDIR / "pdf_structure.pdf", space="default", max_workers=2
     ) as pdf:
-        resources, = list(pdf.pages.map(get_resources))
+        (resources,) = list(pdf.pages.map(get_resources))
         desc = resources["Font"].resolve()  # should succeed!
         assert "F1" in desc  # should exist!
         assert "F2" in desc
@@ -59,5 +59,5 @@ def test_map_parallel():
     assert texts == parallel_texts
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_parallel_references()

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -71,6 +71,10 @@ def test_map_parallel():
     with playa.open(CONTRIB / "PSC_Station.pdf", space="default") as pdf:
         texts = list(pdf.pages.map(get_text))
     assert texts == parallel_texts
+    with playa.open(CONTRIB / "PSC_Station.pdf", space="default", max_workers=2) as pdf:
+        parallel_texts = list(pdf.pages[3:8].map(get_text))
+        print(parallel_texts)
+        assert parallel_texts != texts
 
 
 if __name__ == "__main__":

--- a/tests/test_pdftypes.py
+++ b/tests/test_pdftypes.py
@@ -5,8 +5,7 @@ Test PDF types and data structures.
 from playa.data_structures import NameTree, NumberTree
 from playa.runlength import rldecode
 from playa.pdftypes import ObjRef, resolve1, resolve_all
-
-import weakref
+from playa.worker import _ref_document
 
 NUMTREE1 = {
     "Kids": [
@@ -94,15 +93,15 @@ def test_resolve_all():
         pass
 
     mockdoc = MockDoc({42: "hello"})
-    mockdoc[41] = ObjRef(weakref.ref(mockdoc), 42)
-    mockdoc[40] = ObjRef(weakref.ref(mockdoc), 41)
+    mockdoc[41] = ObjRef(_ref_document(mockdoc), 42)
+    mockdoc[40] = ObjRef(_ref_document(mockdoc), 41)
     assert mockdoc[41].resolve() == "hello"
     assert resolve1(mockdoc[41]) == "hello"
     assert mockdoc[40].resolve() == mockdoc[41]
     assert resolve_all(mockdoc[40]) == "hello"
     mockdoc[39] = [mockdoc[40], mockdoc[41]]
     assert resolve_all(mockdoc[39]) == ["hello", "hello"]
-    mockdoc[38] = ["hello", ObjRef(weakref.ref(mockdoc), 38)]
+    mockdoc[38] = ["hello", ObjRef(_ref_document(mockdoc), 38)]
     # This resolves the *list*, not the indirect object, so its second
     # element will get expanded once into a new list.
     ouf = resolve_all(mockdoc[38])
@@ -113,8 +112,8 @@ def test_resolve_all():
     assert fou[1] is mockdoc[38]
     # Likewise here, we have to dig a bit to see the circular
     # reference.  Your best option is not to use resolve_all ;-)
-    mockdoc[30] = ["hello", ObjRef(weakref.ref(mockdoc), 31)]
-    mockdoc[31] = ["hello", ObjRef(weakref.ref(mockdoc), 30)]
+    mockdoc[30] = ["hello", ObjRef(_ref_document(mockdoc), 31)]
+    mockdoc[31] = ["hello", ObjRef(_ref_document(mockdoc), 30)]
     bof = resolve_all(mockdoc[30])
     assert bof[1][1][1] is mockdoc[31]
     fob = resolve_all(mockdoc[30][1])


### PR DESCRIPTION
It is *somewhat* of a hack, but not really, unless you have an irrational fear of global variables (news flash: functions, modules, and classes are also global objects).

Basically we just pass the `id` of the parent process' `Document` object to the workers, who just use this integer instead of a weak reference when creating `ObjRef` - it can be serialized when returned, and then we just look it up in a table ... of weak references ... to `Document` objects with worker processes.

~We could of course~ We will in fact just do this for all indirect object references, all the time, ~which might be faster in single-threaded code too.~ which is not slower and also simplifies the code somewhat.