### PR TITLE
feat: extract text objects not text badly

### DIFF
--- a/playa/cli.py
+++ b/playa/cli.py
@@ -238,11 +238,12 @@ def get_text_json(page: Page) -> List[str]:
             "line_matrix": tstate.line_matrix,
             "fontsize": tstate.fontsize,
             "render_mode": tstate.render_mode,
-            "font": {
+        }
+        if tstate.font is not None:
+            textstate["font"] = {
                 "fontname": tstate.font.fontname,
                 "vertical": tstate.font.vertical,
-            },
-        }
+            }
         gstate = {
             "scs": text.gstate.scs._asdict(),
             "scolor": text.gstate.scolor._asdict(),

--- a/playa/document.py
+++ b/playa/document.py
@@ -1388,7 +1388,9 @@ class PageList:
     def __iter__(self) -> Iterator[Page]:
         return iter(self._pages)
 
-    def __getitem__(self, key: Union[int, str, slice, Iterable[Union[str, int]]]) -> Union[Page, "PageList"]:
+    def __getitem__(
+        self, key: Union[int, str, slice, Iterable[Union[str, int]]]
+    ) -> Union[Page, "PageList"]:
         if isinstance(key, int):
             return self._pages[key]
         elif isinstance(key, str):

--- a/playa/document.py
+++ b/playa/document.py
@@ -25,6 +25,7 @@ from typing import (
     Sequence,
     Tuple,
     Union,
+    overload,
 )
 
 try:
@@ -1388,9 +1389,22 @@ class PageList:
     def __iter__(self) -> Iterator[Page]:
         return iter(self._pages)
 
-    def __getitem__(
-        self, key: Union[int, str, slice, Iterable[Union[str, int]]]
-    ) -> Union[Page, "PageList"]:
+    @overload
+    def __getitem__(self, key: int) -> Page: ...
+
+    @overload
+    def __getitem__(self, key: str) -> Page: ...
+
+    @overload
+    def __getitem__(self, key: slice) -> "PageList": ...
+
+    @overload
+    def __getitem__(self, key: Iterable[int]) -> "PageList": ...
+
+    @overload
+    def __getitem__(self, key: Iterator[Union[int, str]]) -> "PageList": ...
+
+    def __getitem__(self, key):
         if isinstance(key, int):
             return self._pages[key]
         elif isinstance(key, str):
@@ -1398,7 +1412,6 @@ class PageList:
         elif isinstance(key, slice):
             return PageList(_deref_document(self.docref), self._pages[key])
         else:
-            # Try to iterate over it (exception if we can't)
             return PageList(_deref_document(self.docref), (self[k] for k in key))
 
     def map(self, func: Callable[[Page], Any]) -> Iterator:

--- a/playa/document.py
+++ b/playa/document.py
@@ -1388,15 +1388,16 @@ class PageList:
     def __iter__(self) -> Iterator[Page]:
         return iter(self._pages)
 
-    def __getitem__(self, key: Union[int, str]) -> Page:
+    def __getitem__(self, key: Union[int, str, slice, Iterable[Union[str, int]]]) -> Union[Page, "PageList"]:
         if isinstance(key, int):
             return self._pages[key]
+        elif isinstance(key, str):
+            return self._labels[key]
         elif isinstance(key, slice):
             return PageList(_deref_document(self.docref), self._pages[key])
-        elif isinstance(key, (tuple, list)):
-            return PageList(_deref_document(self.docref), (self[k] for k in key))
         else:
-            return self._labels[key]
+            # Try to iterate over it (exception if we can't)
+            return PageList(_deref_document(self.docref), (self[k] for k in key))
 
     def map(self, func: Callable[[Page], Any]) -> Iterator:
         """Apply a function over each page, iterating over its results.

--- a/playa/page.py
+++ b/playa/page.py
@@ -917,7 +917,7 @@ class TextObject(ContentObject):
         for obj in self.args:
             if not isinstance(obj, bytes):
                 continue
-            for cid, text in font.decode(obj):
+            for _, text in font.decode(obj):
                 self._chars.append(text)
         return "".join(self._chars)
 


### PR DESCRIPTION
Instead of just printing the characters of text objects, print something useful, a JSON representation of `TextObject` (which will be improved to cover other `ContentObject` as well in PLAYA 0.3)

Also do this in parallel if requested.