### PR TITLE
fix: accept empty name objects

### DIFF
--- a/playa/parser.py
+++ b/playa/parser.py
@@ -101,7 +101,7 @@ LEXER = re.compile(
     rb"""(?:
       (?P<whitespace> \s+)
     | (?P<comment> %[^\r\n]*[\r\n])
-    | (?P<name> /(?: \#[A-Fa-f\d][A-Fa-f\d] | [^#/%\[\]()<>{}\s])+ )
+    | (?P<name> /(?: \#[A-Fa-f\d][A-Fa-f\d] | [^#/%\[\]()<>{}\s])* )
     | (?P<number> [-+]? (?: \d*\.\d+ | \d+ ) )
     | (?P<keyword> [A-Za-z] [^#/%\[\]()<>{}\s]*)
     | (?P<startstr> \([^()\\]*)
@@ -365,7 +365,7 @@ class ObjectParser:
                 try:
                     pos, obj = self.pop_to(KEYWORD_ARRAY_BEGIN)
                 except TypeError as e:
-                    log.warning(f"When constructing array: {e}")
+                    log.warning("When constructing array from %r: %s", obj, e)
                 if pos == top:
                     top = None
                     return pos, obj
@@ -388,7 +388,7 @@ class ObjectParser:
                         if v is not None
                     }
                 except TypeError as e:
-                    log.warning(f"When constructing dict: {e}")
+                    log.warning("When constructing dict from %r: %s", objs, e)
                 if pos == top:
                     top = None
                     return pos, obj
@@ -401,7 +401,7 @@ class ObjectParser:
                 try:
                     pos, obj = self.pop_to(KEYWORD_PROC_BEGIN)
                 except TypeError as e:
-                    log.warning(f"When constructing proc: {e}")
+                    log.warning("When constructing proc from %r: %s", obj, e)
                 if pos == top:
                     top = None
                     return pos, obj

--- a/tests/test_object_parser.py
+++ b/tests/test_object_parser.py
@@ -38,7 +38,7 @@ baa)
 12345>
 func/a/b{(c)do*}def
 [ 1 (z) ! ]
-<< /foo (bar) >>
+<< /foo (bar) / (baz) >>
 """
 TOKENS1 = [
     (5, KWD(b"begin")),
@@ -86,7 +86,9 @@ TOKENS1 = [
     (258, KWD(b"<<")),
     (261, LIT("foo")),
     (266, b"bar"),
-    (272, KWD(b">>")),
+    (272, LIT("")),
+    (274, b"baz"),
+    (280, KWD(b">>")),
 ]
 OBJS1 = [
     (5, KWD(b"begin")),
@@ -124,7 +126,7 @@ OBJS1 = [
     (234, [b"c", KWD(b"do*")]),
     (242, KWD(b"def")),
     (246, [1, b"z", KWD(b"!")]),
-    (258, {"foo": b"bar"}),
+    (258, {"foo": b"bar", "": b"baz"}),
 ]
 
 


### PR DESCRIPTION
PDF 1.7 sec 7.3.5: The token SOLIDUS (a slash followed by no regular characters) introduces a unique valid name defined by the empty sequence of characters.