### PR TITLE
feat: Add backreferences to content objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,13 @@ page = pdf.pages["42"]     # or "logical" page number (also a string)
 print(f"Page {page.label} is {page.width} x {page.height}")
 ```
 
+You can also subscript `pdf.pages` in various other ways, using a
+slice or an iterable of `int`, which will give you a page list object
+that behaves similarly to `pdf.pages`.
+
+Pages and page lists can refer back to their document (using weak
+reference magic to avoid memory leaks) with the `doc` property.
+
 ## Accessing content
 
 What are these "contents" of which you speak, which were surely
@@ -299,6 +306,16 @@ will *always* have a `tag`.
 PDF also has the concept of "marked content points". PLAYA suports
 these with objects of `object_type == "tag"`.  The tag name and
 properties are also accessible via the `mcs` attribute.
+
+You may also wish to know the complete stack of enclosing marked
+content sections.  This is accessible from the `mcstack` property.
+Note that though it's called a "stack", it's actually a tuple.  This
+means that it is immutable, and you can check if it has changed from
+one object to the next using the `is` operator.
+
+All content objects can also refer back to their containing `Page`
+from the `page` property.  This uses weak reference magic in order to
+avoid causing memory leaks.
 
 ### Form XObjects
 

--- a/playa/page.py
+++ b/playa/page.py
@@ -479,6 +479,7 @@ class ContentObject:
       mcstack: Stack of enclosing marked content sections.
     """
 
+    _pageref: PageRef
     gstate: GraphicState
     ctm: Matrix
     mcstack: List[MarkedContent]
@@ -519,6 +520,11 @@ class ContentObject:
             if mcs.mcid is not None:
                 return mcs.mcid
         return None
+
+    @property
+    def page(self) -> Page:
+        """The page containing this content object."""
+        return _deref_page(self._pageref)
 
 
 BBOX_NONE = (-1, -1, -1, -1)
@@ -630,7 +636,6 @@ class XObjectObject(ContentObject):
     xobjid: str
     stream: ContentStream
     resources: Union[None, Dict[str, PDFObject]]
-    _pageref: PageRef
 
     def __contains__(self, name: object) -> bool:
         return name in self.stream
@@ -716,6 +721,7 @@ class PathObject(ContentObject):
         for seg in self.raw_segments:
             if seg.operator == "m" and segs:
                 yield PathObject(
+                    _pageref=self._pageref,
                     gstate=self.gstate,
                     ctm=self.ctm,
                     mcstack=self.mcstack,
@@ -728,6 +734,7 @@ class PathObject(ContentObject):
             segs.append(seg)
         if segs:
             yield PathObject(
+                _pageref=self._pageref,
                 gstate=self.gstate,
                 ctm=self.ctm,
                 mcstack=self.mcstack,
@@ -888,6 +895,7 @@ class TextObject(ContentObject):
                     adv = textwidth * tstate.fontsize * scaling
                     x, y = tstate.glyph_offset
                     glyph = GlyphObject(
+                        _pageref=self._pageref,
                         gstate=self.gstate,
                         ctm=self.ctm,
                         mcstack=self.mcstack,
@@ -1074,6 +1082,7 @@ class LazyInterpreter:
 
     def create(self, object_class, **kwargs) -> ContentObject:
         return object_class(
+            _pageref=_ref_page(self.page),
             ctm=self.ctm,
             mcstack=self.mcstack,
             gstate=self.graphicstate,
@@ -1238,13 +1247,13 @@ class LazyInterpreter:
             xobjres = xobj.get("Resources")
             resources = None if xobjres is None else dict_value(xobjres)
             xobjobj = XObjectObject(
+                _pageref=_ref_page(self.page),
                 ctm=mult_matrix(matrix, self.ctm),
                 mcstack=self.mcstack,
                 gstate=self.graphicstate,
                 xobjid=xobjid,
                 stream=xobj,
                 resources=resources,
-                _pageref=_ref_page(self.page),
             )
             # We are *lazy*, so just yield the XObject itself not its contents
             yield xobjobj
@@ -1282,6 +1291,7 @@ class LazyInterpreter:
             props = self.get_property(props)
         rprops = {} if props is None else dict_value(props)
         yield TagObject(
+            _pageref=_ref_page(self.page),
             ctm=self.ctm,
             mcstack=self.mcstack,
             gstate=self.graphicstate,


### PR DESCRIPTION
This is largely (but not entirely) to support easy visualization in an upcoming PAVÉS.

It doesn't seem to cause any performance hit (after all the references are just tuples of ints) but will use a bit more memory.