### PR TITLE
Import and re-export a lot of types at top level

### DIFF
--- a/playa/__init__.py
+++ b/playa/__init__.py
@@ -22,9 +22,10 @@ from typing import Union
 from playa.worker import _init_worker
 from playa.document import Document
 from playa.page import Page, DeviceSpace
+from playa.pdftypes import resolve1 as resolve, resolve_all
 from playa._version import __version__
 
-__all__ = ["Document", "Page", "DeviceSpace", "__version__"]
+__all__ = ["Document", "Page", "DeviceSpace", "resolve", "resolve_all", "__version__"]
 
 
 def open(

--- a/playa/__init__.py
+++ b/playa/__init__.py
@@ -20,12 +20,44 @@ from multiprocessing.context import BaseContext
 from typing import Union
 
 from playa.worker import _init_worker
-from playa.document import Document
-from playa.page import Page, DeviceSpace
-from playa.pdftypes import resolve1 as resolve, resolve_all
+from playa.color import Color, ColorSpace
+from playa.document import Document, PageList
+from playa.page import (
+    Page,
+    DeviceSpace,
+    ContentObject,
+    MarkedContent,
+    PathSegment,
+    GraphicState,
+    TextState,
+)
+from playa.parser import Token
+from playa.pdftypes import resolve1 as resolve, resolve_all, ContentStream, ObjRef
+from playa.utils import Matrix, Point, Rect
 from playa._version import __version__
 
-__all__ = ["Document", "Page", "DeviceSpace", "resolve", "resolve_all", "__version__"]
+__all__ = [
+    "Document",
+    "Page",
+    "PageList",
+    "DeviceSpace",
+    "Color",
+    "ColorSpace",
+    "ContentObject",
+    "ContentStream",
+    "GraphicState",
+    "MarkedContent",
+    "Matrix",
+    "Point",
+    "Rect",
+    "PathSegment",
+    "TextState",
+    "Token",
+    "ObjRef",
+    "resolve",
+    "resolve_all",
+    "__version__",
+]
 
 
 def open(

--- a/playa/cli.py
+++ b/playa/cli.py
@@ -301,7 +301,7 @@ def extract_page_contents(doc: Document, args: argparse.Namespace) -> None:
 def get_text_from_obj(obj: TextObject, vertical: bool) -> Tuple[str, float]:
     """Try to get text from a text object."""
     chars = []
-    prev_end = 0.
+    prev_end = 0.0
     for glyph in obj:
         x, y = glyph.textstate.glyph_offset
         off = y if vertical else x
@@ -317,7 +317,7 @@ def get_text_from_obj(obj: TextObject, vertical: bool) -> Tuple[str, float]:
 def get_text_untagged(page: Page) -> str:
     """Get text from a page of an untagged PDF."""
     prev_line_matrix = None
-    prev_end = 0.
+    prev_end = 0.0
     lines = []
     strings = []
     for text in page.texts:


### PR DESCRIPTION
To avoid hideous endless lists import statements such as one experiences when using `pdfminer.six`