### PR TITLE
feat: new APIs, flatten, extract_text, is_tagged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## PLAYA 0.3.0: unreleased
 
+- API for text extraction
+- Extract text from XObjects with `playa --text`
 - Remove deprecated `LayoutDict` API and simplify code
 - Deprecate `annots` API and add friendly `annotations`
 - Elevate `resolve1` and `resolve_all` to top-level exports
@@ -10,10 +12,12 @@
 ### TODO
 
 - Deprecate `outlines` API and add tree-structured `outline`
+  - Link structured elements in outline to structure tree (lazily)
 - Deprecate `dests` API and add friendly `destinations`
 - Create friendly API for actions
 - Expose `XRef` API for users to look around in
-- Format all `ContentObject` as JSON
+- Methods for all `ContentObject` to format as JSON/dict
+  - Do not want to use Pydantic but be Pydantic-like
 
 ## PLAYA 0.2.10: 2025-02-18
 - Fix serious bug in rare ' and " text operators

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The purpose of PLAYA is to provide an efficent, parallel and
 parallelizable, pure-Python and Pythonic (for its author's definition
 of the term), lazy interface to the internals of PDF files.
 
-If you just want to extract text from a PDF, there are a better and/or
+If you just want to extract text from a PDF, there are better and/or
 faster tools and libraries out there, notably
 [pypdfium2](https://pypi.org/project/pypdfium2/) and
 [pypdf](https://pypi.org/project/pypdf/), among others.  See [these
@@ -149,7 +149,7 @@ page = pdf.pages["42"]     # or "logical" page number (also a string)
 print(f"Page {page.label} is {page.width} x {page.height}")
 ```
 
-Since PDF is at heard a page-oriented, presentation format, many types
+Since PDF is at heart a page-oriented, presentation format, many types
 of metadata are mostly accessible via the page objects.
 
 For example, annotations (internal or external links) are only
@@ -296,9 +296,16 @@ in the aforementioned interpretation of "device space"):
 ```python
 for obj in page:
     print(f"{obj.object_type} at {obj.bbox}")
+
+    # With space="screen" (the default)
     left, top, right, bottom = obj.bbox
     print(f"  top left is {left, top}")
-    print(f"  bottom right is {right, botom}")
+    print(f"  bottom right is {right, bottom}")
+
+    # With space="page" or space="default"
+    left, bottom, right, top = obj.bbox
+    print(f"  bottom left is {left, bottom}")
+    print(f"  top right is {right, top}")
 ```
 
 Another important piece of information (which `pdfminer.six` does not

--- a/benchmarks/text.py
+++ b/benchmarks/text.py
@@ -26,15 +26,34 @@ def benchmark_chars(path: Path):
                     _ = obj.chars
 
 
+def benchmark_text(path: Path):
+    """Extract text, sort of."""
+    import playa
+
+    if path.name in PDFMINER_BUGS or path.name in XFAILS:
+        return
+    passwords = PASSWORDS.get(path.name, [""])
+    for password in passwords:
+        LOG.info("Reading %s", path)
+        with playa.open(path, password=password) as pdf:
+            for page in pdf.pages:
+                page.extract_text()
+
+
 if __name__ == "__main__":
     # Silence warnings about broken PDFs
     logging.basicConfig(level=logging.ERROR)
     niter = 5
-    miner_time = beach_time = lazy_time = 0.0
+    chars_time = text_time = 0.0
     for iter in range(niter + 1):
         for path in BASEPDFS:
             start = time.time()
             benchmark_chars(path)
             if iter != 0:
-                lazy_time += time.time() - start
-    print("chars took %.2fs / iter" % (lazy_time / niter,))
+                chars_time += time.time() - start
+            start = time.time()
+            benchmark_text(path)
+            if iter != 0:
+                text_time += time.time() - start
+    print("chars took %.2fs / iter" % (chars_time / niter,))
+    print("extract_text took %.2fs / iter" % (text_time / niter,))

--- a/playa/document.py
+++ b/playa/document.py
@@ -902,6 +902,7 @@ class Document:
                 self.pdf_version,
             )
             self.pdf_version = self.catalog["Version"]
+        self.is_tagged = "MarkInfo" in self.catalog and self.catalog["MarkInfo"].get("Marked")
 
     def _initialize_password(self, password: str = "") -> None:
         """Initialize the decryption handler with a given password, if any.

--- a/playa/document.py
+++ b/playa/document.py
@@ -902,7 +902,10 @@ class Document:
                 self.pdf_version,
             )
             self.pdf_version = self.catalog["Version"]
-        self.is_tagged = "MarkInfo" in self.catalog and self.catalog["MarkInfo"].get("Marked")
+        self.is_tagged = False
+        markinfo = resolve1(self.catalog.get("MarkInfo"))
+        if isinstance(markinfo, dict):
+            self.is_tagged = not not markinfo.get("Marked")
 
     def _initialize_password(self, password: str = "") -> None:
         """Initialize the decryption handler with a given password, if any.

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -10,6 +10,7 @@ import playa
 from playa.data_structures import NameTree
 from playa.document import read_header, XRefTable
 from playa.exceptions import PDFSyntaxError
+from playa.page import TextObject
 from playa.parser import LIT
 from playa.utils import decode_text
 from .data import CONTRIB, TESTDIR
@@ -160,6 +161,12 @@ def test_xobjects() -> None:
         xobj = next(page.xobjects)
         assert xobj.object_type == "xobject"
         assert len(list(xobj)) == 2
+
+        for obj in page.flatten():
+            assert obj.object_type != "xobject"
+
+        for obj in page.flatten(TextObject):
+            assert isinstance(obj, TextObject)
 
 
 def test_annotations() -> None:

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -174,3 +174,10 @@ def test_annotations() -> None:
         page = doc.pages[0]
         for annot in page.annotations:
             assert annot.page is page
+
+
+def test_is_tagged() -> None:
+    with playa.open(TESTDIR / "simple1.pdf") as doc:
+        assert not doc.is_tagged
+    with playa.open(TESTDIR / "pdf_structure.pdf") as doc:
+        assert doc.is_tagged


### PR DESCRIPTION
Add a few highly useful APIs:

- `Document.is_tagged`: is this a tagged PDF (according to the standard)?
- `Page.flatten`: iterate over all objects, recursing into XObjects, optionally filtering by type (other overloads are possible here in the near future)
- `Page.extract_text`: yes, it finally happened, since it turns out that we beat everybody else except `pypdf` on the benchmarks