### PR TITLE
Support pdfannots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## PLAYA 0.3.1: 2025-02-28
+
+- Correct CTM in children of XObjectObject
+- Add `have_labels` attribute to PageList
+
 ## PLAYA 0.3.0: 2025-02-20
 
 - API for text extraction

--- a/playa/document.py
+++ b/playa/document.py
@@ -143,7 +143,7 @@ class Document:
 
     Args:
       fp: File-like object in binary mode, or a buffer with binary data.
-          Files Will be read using `mmap` if possible.  They do not need
+          Files will be read using `mmap` if possible.  They do not need
           to be seekable, as if `mmap` fails the entire file will simply
           be read into memory (so a pipe or socket ought to work).
       password: Password for decryption, if needed.
@@ -770,7 +770,13 @@ def call_page(func: Callable[[Page], Any], pageref: PageRef) -> Any:
 
 
 class PageList:
-    """List of pages indexable by 0-based index or string label."""
+    """List of pages indexable by 0-based index or string label.
+
+    Attributes:
+        have_labels: If pages have explicit labels in the PDF.
+    """
+
+    have_labels: bool
 
     def __init__(
         self, doc: Document, pages: Union[Iterable[Page], None] = None
@@ -781,14 +787,17 @@ class PageList:
             self._labels: Dict[str, Page] = {
                 page.label: page for page in pages if page.label is not None
             }
+            self.have_labels = not not self._labels
         else:
             self._init_pages(doc)
 
     def _init_pages(self, doc: Document) -> None:
         try:
             page_labels: Iterable[Union[str, None]] = doc.page_labels
+            self.have_labels = True
         except (KeyError, ValueError):
             page_labels = (str(idx) for idx in itertools.count(1))
+            self.have_labels = False
         self._pages = []
         self._objids = {}
         self._labels = {}

--- a/playa/page.py
+++ b/playa/page.py
@@ -508,7 +508,8 @@ class Annotation:
 
     Attributes:
       subtype: Type of annotation.
-      rect: Annotation rectangle (location on page).
+      rect: Annotation rectangle (location on page) in *default user space*
+      bbox: Annotation rectangle in *device space*
       contents: Text contents.
       props: Annotation dictionary containing all other properties
              (PDF 1.7 sec. 12.5.2).
@@ -913,7 +914,9 @@ class XObjectObject(ContentObject):
             yield obj
 
     def __iter__(self) -> Iterator["ContentObject"]:
-        return iter(LazyInterpreter(self.page, [self.stream], self.resources))
+        interp = LazyInterpreter(self.page, [self.stream], self.resources)
+        interp.ctm = self.ctm
+        return iter(interp)
 
 
 @dataclass

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -185,8 +185,20 @@ def test_xobjects() -> None:
         for obj in page.flatten():
             assert obj.object_type != "xobject"
 
+        boxes = []
         for obj in page.flatten(TextObject):
             assert isinstance(obj, TextObject)
+            boxes.append(tuple(round(x) for x in obj.bbox))
+        # Make sure they are in the right place!
+        assert boxes == [
+            (136, 16, 136, 17),
+            (238, 80, 358, 96),
+            (45, 119, 116, 131),
+            (118, 118, 550, 130),
+            (61, 134, 142, 145),
+            (147, 133, 550, 145),
+            (389, 816, 546, 828),
+        ]
 
 
 def test_annotations() -> None:


### PR DESCRIPTION
Fix a very atrocious bug that was revealed by pdfannots' test suite (thanks!)

Namely the CTM was not being passed into iteration over Form XObjects, so the child objects ended up with the wrong bboxes.