### PR TITLE
fix: Decrypt all the things

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## PLAYA 0.3.2: 2025-02-18
+- Decrypt objects in `Document.objects` iterator
+
 ## PLAYA 0.3.1: 2025-02-28
 
 - Correct CTM in children of XObjectObject

--- a/playa/__init__.py
+++ b/playa/__init__.py
@@ -22,7 +22,7 @@ from typing import Union
 from playa.worker import _init_worker, _init_worker_buffer
 from playa.color import Color, ColorSpace
 from playa.document import Document, PageList
-from playa.exceptions import PDFException
+from playa.exceptions import PDFException, PDFPasswordIncorrect, PDFEncryptionError
 from playa.page import (
     Page,
     DeviceSpace,
@@ -56,6 +56,8 @@ __all__ = [
     "Token",
     "ObjRef",
     "PDFException",
+    "PDFPasswordIncorrect",
+    "PDFEncryptionError",
     "resolve",
     "resolve_all",
     "__version__",

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -213,3 +213,16 @@ def test_is_tagged() -> None:
         assert not doc.is_tagged
     with playa.open(TESTDIR / "pdf_structure.pdf") as doc:
         assert doc.is_tagged
+
+
+def test_objects_decrypted() -> None:
+    with playa.open(TESTDIR / "encryption" / "rc4-40.pdf", password="foo") as doc:
+        info = None
+        for obj in doc.objects:
+            if obj.objid == 10:
+                info = obj
+        assert info is not None
+        # Make sure strings are decrypted in both cases
+        assert info.obj == doc[10]
+        assert isinstance(info.obj, dict)
+        assert info.obj["CreationDate"] == b"D:20140509193727+02'00'"


### PR DESCRIPTION
When iterating over objects in an encrypted with `Document.objects`, the object data wasn't actually being decrypted for top-level indirect objects.