### PR TITLE
Remove at least one footgun from `TextObject`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## PLAYA 0.3.2: 2025-02-18
 - Decrypt objects in `Document.objects` iterator
+- Remove disastrous side-effects from `TextObject.bbox`
 
 ## PLAYA 0.3.1: 2025-02-28
 

--- a/tests/test_lazy_api.py
+++ b/tests/test_lazy_api.py
@@ -101,6 +101,22 @@ def test_rotated_glyphs() -> None:
         assert "".join(chars) == "R18,00"
 
 
+def test_rotated_text_objects() -> None:
+    """Verify specializations of bbox for text."""
+    with playa.open(TESTDIR / "rotated.pdf") as pdf:
+        # Ensure that the text bbox is the same as the bounds of the
+        # glyph bboxes (this will also ensure no side effects)
+        for text in pdf.pages[0].texts:
+            bbox = text.bbox
+            points = []
+            for glyph in text:
+                x0, y0, x1, y1 = glyph.bbox
+                print(glyph.text, ":", glyph.bbox)
+                points.append((x0, y0))
+                points.append((x1, y1))
+            assert bbox == pytest.approx(get_bound(points))
+
+
 def test_rotated_bboxes() -> None:
     """Verify that rotated bboxes are correctly calculated."""
     points = ((0, 0), (0, 100), (100, 100), (100, 0))


### PR DESCRIPTION
Yes, `TextObject.bbox` had side effects, that was very bad.

`TextObject.bbox.__iter__` still has side effects for the moment, though at least this is documented.

This also adds useful properties for getting glyph/text object bounds in text space, which should allow us to get bounding quadrilaterals (like docling-parse does)

Finally, it also speeds up `TextObject.bbox` (but not `GlyphObject.bbox`, sadly) by about 20%.