### PR TITLE
Fix a few annoyances in logical structure trees

### DIFF
--- a/playa/cli.py
+++ b/playa/cli.py
@@ -428,6 +428,9 @@ def _extract_element(el: Element, indent: int, outfh: TextIO) -> bool:
     except KeyError:
         LOG.warning("Structure element with no type ignored: %r", el)
         return False
+    except TypeError:
+        LOG.warning("Structure element with invalid type ignored: %r", el)
+        return False
     page = el.page
     if page is not None:
         format_attr("page_idx", page.page_idx)

--- a/playa/cli.py
+++ b/playa/cli.py
@@ -423,7 +423,11 @@ def _extract_element(el: Element, indent: int, outfh: TextIO) -> bool:
         v = json.dumps(v, ensure_ascii=False)
         s.append(f"{ws}{ss}{k}: {v}")
 
-    format_attr("type", el.type)
+    try:
+        format_attr("type", el.type)
+    except KeyError:
+        LOG.warning("Structure element with no type ignored: %r", el)
+        return False
     page = el.page
     if page is not None:
         format_attr("page_idx", page.page_idx)

--- a/playa/data/metadata.py
+++ b/playa/data/metadata.py
@@ -521,15 +521,16 @@ def asobj_stream(obj: _ContentStream) -> Dict:
 
 
 @asobj.register
-def asobj_outline(obj: _Outline) -> Outline:
+def asobj_outline(obj: _Outline, recurse: bool = True) -> Outline:
     out = Outline()
     if obj.title is not None:
         out["title"] = decode_text(obj.title)
     if obj.destination is not None:
         out["destination"] = asobj(obj.destination)
-    children = list(obj)
-    if children:
-        out["children"] = asobj(children)
+    if recurse:
+        children = list(obj)
+        if children:
+            out["children"] = asobj(children)
     return out
 
 
@@ -571,7 +572,7 @@ def asobj_content_object(obj: _StructContentObject) -> StructContentObject:
 
 
 @asobj.register
-def asobj_structelement(obj: _Element) -> StructElement:
+def asobj_structelement(obj: _Element, recurse: bool = True) -> StructElement:
     el = StructElement()
     page = obj.page
     if page is not None:
@@ -586,15 +587,19 @@ def asobj_structelement(obj: _Element) -> StructElement:
         el["abbreviation_expansion"] = decode_text(resolve1(obj.props["E"]))
     if "ActualText" in obj.props:
         el["actual_text"] = decode_text(resolve1(obj.props["ActualText"]))
-    children = [asobj(el) for el in obj]
-    if children:
-        el["children"] = children
+    if recurse:
+        children = [asobj(el) for el in obj]
+        if children:
+            el["children"] = children
     return el
 
 
 @asobj.register
-def asobj_structtree(obj: _Tree) -> StructTree:
-    root = StructElement(type="StructTreeRoot", children=[asobj(el) for el in obj])
+def asobj_structtree(obj: _Tree, recurse: bool = True) -> StructTree:
+    root = StructElement(
+        type="StructTreeRoot",
+        children=[asobj_structelement(el, recurse=recurse) for el in obj],
+    )
     return StructTree(root=root)
 
 

--- a/playa/data/metadata.py
+++ b/playa/data/metadata.py
@@ -595,10 +595,10 @@ def asobj_structelement(obj: _Element, recurse: bool = True) -> StructElement:
 
 
 @asobj.register
-def asobj_structtree(obj: _Tree, recurse: bool = True) -> StructTree:
+def asobj_structtree(obj: _Tree) -> StructTree:
     root = StructElement(
         type="StructTreeRoot",
-        children=[asobj_structelement(el, recurse=recurse) for el in obj],
+        children=[asobj(el) for el in obj],
     )
     return StructTree(root=root)
 

--- a/playa/structure.py
+++ b/playa/structure.py
@@ -197,112 +197,124 @@ class Element(Findable):
     def __iter__(self) -> Iterator[Union["Element", ContentItem, ContentObject]]:
         if "K" in self.props:
             kids = resolve1(self.props["K"])
-            yield from self._make_kids(kids)
+            yield from _make_kids(kids, self.page, self._docref)
 
-    @functools.singledispatchmethod
-    def _make_kids(
-        self, k: PDFObject
-    ) -> Iterator[Union["Element", ContentItem, ContentObject]]:
-        """
-        Make a child for this element from its K array.
 
-        K in Element can be (PDF 1.7 Table 323):
-        - a structure element (not a content item)
-        - an integer marked-content ID
-        - a marked-content reference dictionary
-        - an object reference dictionary
-        - an array of one or more of the above
-        """
-        LOG.warning("Unrecognized 'K' element: %r", k)
-        yield from ()
+@functools.singledispatch
+def _make_kids(
+    k: PDFObject, page: Union["Page", None], docref: DocumentRef
+) -> Iterator[Union["Element", ContentItem, ContentObject]]:
+    """
+    Make a child for this element from its K array.
 
-    @_make_kids.register(list)
-    def _make_kids_list(
-        self, k: list
-    ) -> Iterator[Union["Element", ContentItem, ContentObject]]:
-        for el in k:
-            yield from self._make_kids(resolve1(el))
+    K in Element can be (PDF 1.7 Table 323):
+    - a structure element (not a content item)
+    - an integer marked-content ID
+    - a marked-content reference dictionary
+    - an object reference dictionary
+    - an array of one or more of the above
+    """
+    LOG.warning("Unrecognized 'K' element: %r", k)
+    yield from ()
 
-    @_make_kids.register(int)
-    def _make_kids_int(self, k: int) -> Iterator[ContentItem]:
-        page = self.page
-        if page is None:
-            LOG.warning("No page found for marked-content reference: %r", k)
-            return
-        yield ContentItem(_pageref=page.pageref, mcid=k, stream=None)
 
-    @_make_kids.register(dict)
-    def _make_kids_dict(
-        self, k: Dict[str, PDFObject]
-    ) -> Iterator[Union[ContentItem, ContentObject, "Element"]]:
-        ktype = k.get("Type")
-        if ktype is LITERAL_MCR:
-            yield from self._make_kids_mcr(k)
-        elif ktype is LITERAL_OBJR:
-            yield from self._make_kids_objr(k)
-        else:
-            yield Element(_docref=self._docref, props=k)
+@_make_kids.register(list)
+def _make_kids_list(
+    k: list, page: Union["Page", None], docref: DocumentRef
+) -> Iterator[Union["Element", ContentItem, ContentObject]]:
+    for el in k:
+        yield from _make_kids(resolve1(el), page, docref)
 
-    def _make_kids_mcr(self, k: Dict[str, PDFObject]) -> Iterator[ContentItem]:
-        mcid = resolve1(k.get("MCID"))
-        if mcid is None or not isinstance(mcid, int):
-            LOG.warning("'MCID' entry is not an int: %r", k)
-            return
-        stream: Union[ContentStream, None] = None
-        pageref = self._get_kid_pageref(k)
+
+@_make_kids.register(int)
+def _make_kids_int(
+    k: int, page: Union["Page", None], docref: DocumentRef
+) -> Iterator[ContentItem]:
+    if page is None:
+        LOG.warning("No page found for marked-content reference: %r", k)
+        return
+    yield ContentItem(_pageref=page.pageref, mcid=k, stream=None)
+
+
+@_make_kids.register(dict)
+def _make_kids_dict(
+    k: Dict[str, PDFObject], page: Union["Page", None], docref: DocumentRef
+) -> Iterator[Union[ContentItem, ContentObject, "Element"]]:
+    ktype = k.get("Type")
+    if ktype is LITERAL_MCR:
+        yield from _make_kids_mcr(k, page, docref)
+    elif ktype is LITERAL_OBJR:
+        yield from _make_kids_objr(k, page, docref)
+    else:
+        yield Element(_docref=docref, props=k)
+
+
+def _make_kids_mcr(
+    k: Dict[str, PDFObject], page: Union["Page", None], docref: DocumentRef
+) -> Iterator[ContentItem]:
+    mcid = resolve1(k.get("MCID"))
+    if mcid is None or not isinstance(mcid, int):
+        LOG.warning("'MCID' entry is not an int: %r", k)
+        return
+    stream: Union[ContentStream, None] = None
+    pageref = _get_kid_pageref(k, page, docref)
+    if pageref is None:
+        return
+    try:
+        stream = stream_value(k["Stm"])
+    except KeyError:
+        pass
+    except TypeError:
+        LOG.warning("'Stm' entry is not a content stream: %r", k)
+    # Do not care about StmOwn, we don't do appearances
+    yield ContentItem(_pageref=pageref, mcid=mcid, stream=stream)
+
+
+def _make_kids_objr(
+    k: Dict[str, PDFObject], page: Union["Page", None], docref: DocumentRef
+) -> Iterator[Union[ContentObject, "Element"]]:
+    ref = k.get("Obj")
+    if not isinstance(ref, ObjRef):
+        LOG.warning("'Obj' entry is not an indirect object reference: %r", k)
+        return
+    obj = ref.resolve()
+    if not isinstance(obj, dict):
+        LOG.warning("'Obj' entry does not point to a dict: %r", obj)
+        return
+    # In theory OBJR is not for elements, but just in case...
+    ktype = obj.get("Type")
+    if ktype is LITERAL_STRUCTELEM:
+        yield Element(_docref=docref, props=obj)
+    else:
+        pageref = _get_kid_pageref(k, page, docref)
         if pageref is None:
             return
-        try:
-            stream = stream_value(k["Stm"])
-        except KeyError:
-            pass
-        except TypeError:
-            LOG.warning("'Stm' entry is not a content stream: %r", k)
-        # Do not care about StmOwn, we don't do appearances
-        yield ContentItem(_pageref=pageref, mcid=mcid, stream=stream)
+        yield ContentObject(_pageref=pageref, props=obj)
 
-    def _make_kids_objr(
-        self, k: Dict[str, PDFObject]
-    ) -> Iterator[Union[ContentObject, "Element"]]:
-        ref = k.get("Obj")
-        if not isinstance(ref, ObjRef):
-            LOG.warning("'Obj' entry is not an indirect object reference: %r", k)
-            return
-        obj = ref.resolve()
-        if not isinstance(obj, dict):
-            LOG.warning("'Obj' entry does not point to a dict: %r", obj)
-            return
-        # In theory OBJR is not for elements, but just in case...
-        ktype = obj.get("Type")
-        if ktype is LITERAL_STRUCTELEM:
-            yield Element(_docref=self._docref, props=obj)
+
+def _get_kid_pageref(
+    k: Dict[str, PDFObject], page: Union["Page", None], docref: DocumentRef
+) -> Union[PageRef, None]:
+    pg = k.get("Pg")
+    if pg is not None:
+        if isinstance(pg, ObjRef):
+            try:
+                doc = _deref_document(docref)
+                page = doc.pages.by_id(pg.objid)
+            except KeyError:
+                LOG.warning("'Pg' entry not found in document: %r", k)
         else:
-            pageref = self._get_kid_pageref(k)
-            if pageref is None:
-                return
-            yield ContentObject(_pageref=pageref, props=obj)
-
-    def _get_kid_pageref(self, k: Dict[str, PDFObject]) -> Union[PageRef, None]:
-        pg = k.get("Pg")
-        page: Union[Page, None] = None
-        if pg is not None:
-            if isinstance(pg, ObjRef):
-                try:
-                    page = self.doc.pages.by_id(pg.objid)
-                except KeyError:
-                    LOG.warning("'Pg' entry not found in document: %r", k)
-                    page = None
-            else:
-                LOG.warning("'Pg' entry is not an indirect object reference: %r", k)
+            LOG.warning("'Pg' entry is not an indirect object reference: %r", k)
+    if page is None:
         if page is None:
-            page = self.page
-            if page is None:
-                LOG.warning("No page found for marked-content reference: %r", k)
-                return None
-        return page.pageref
+            LOG.warning("No page found for marked-content reference: %r", k)
+            return None
+    return page.pageref
 
 
-def _iter_structure(doc: "Document") -> Iterator[Element]:
+def _iter_structure(
+    doc: "Document",
+) -> Iterator[Union["Element", ContentItem, ContentObject]]:
     root = resolve1(doc.catalog.get("StructTreeRoot"))
     if root is None:
         return
@@ -324,19 +336,19 @@ def _iter_structure(doc: "Document") -> Iterator[Element]:
         return
     for k in kids:
         k = resolve1(k)
+        # Notwithstanding, we will accept other things in
+        # StructTreeRoot, even though, unlike other things forbidden
+        # by the PDF standard, it seems that this actually never
+        # happens (amazing!).  But we will complain about it.
         if not isinstance(k, dict):
             LOG.warning("'K' entry in StructTreeRoot contains non-element %r", k)
-            continue
-        # Should not happen?!?!?!?
-        if k.get("Type") is LITERAL_OBJR:
+        elif k.get("Type") is LITERAL_OBJR:
             LOG.warning("'K' entry in StructTreeRoot contains object reference %r", k)
-            continue
-        if k.get("Type") is LITERAL_MCR:
+        elif k.get("Type") is LITERAL_MCR:
             LOG.warning(
                 "'K' entry in StructTreeRoot contains marked content reference %r", k
             )
-            continue
-        yield Element.from_dict(doc, k)
+        yield from _make_kids(k, None, _ref_document(doc))
 
 
 class Tree(Findable):
@@ -345,7 +357,7 @@ class Tree(Findable):
     def __init__(self, doc: "Document") -> None:
         self._docref = _ref_document(doc)
 
-    def __iter__(self) -> Iterator[Element]:
+    def __iter__(self) -> Iterator[Union["Element", ContentItem, ContentObject]]:
         doc = _deref_document(self._docref)
         return _iter_structure(doc)
 

--- a/samples/hello_structure.pdf
+++ b/samples/hello_structure.pdf
@@ -1,0 +1,176 @@
+%PDF-1.4
+1 0 obj
+  << /Type /Catalog
+     /Outlines 2 0 R
+     /Pages 3 0 R
+     /StructTreeRoot 7 0 R
+  >>
+endobj
+
+2 0 obj
+  << /Type /Outlines
+     /Count 0
+  >>
+endobj
+
+3 0 obj
+  << /Type /Pages
+     /MediaBox [0 0 612 792]
+     /Kids [4 0 R 11 0 R]
+     /Count 2
+  >>
+endobj
+
+4 0 obj
+  << /Type /Page
+     /Parent 3 0 R
+     /Contents 6 0 R
+     /StructParents 0
+     /Resources << /ProcSet [/PDF /Text]
+                   /Font << /F1 5 0 R >>
+                >>
+  >>
+endobj
+
+5 0 obj
+  << /Type /Font
+     /Subtype /Type1
+     /Name /F1
+     /BaseFont /Helvetica
+  >>
+endobj
+
+6 0 obj
+  << /Length 87 >>
+stream
+  /H1 <</MCID 1>> BDC
+  BT
+    /F1 24 Tf
+    100 700 Td
+    (Hello World) Tj
+  ET
+  EMC
+endstream
+endobj
+
+7 0 obj
+  << /Type /StructTreeRoot
+     /ParentTree 8 0 R
+     /RoleMap << /Title /P >>
+     /ClassMap << /C1 << /O /Foo /A1 1 >>
+                  /C2 << /O /Foo /A1 3 >>
+               >>
+     /K [9 0 R
+         << /Type /OBJR /Pg 11 0 R /Obj 14 0 R >>]
+  >>
+endobj
+
+8 0 obj
+  << /Nums [
+            0 [10 0 R]
+            1 [13 0 R 14 0 R]
+           ]
+  >>
+endobj
+
+9 0 obj
+  << /Type /StructElem
+     /S /Section
+     /Pg 4 0 R
+     /P 7 0 R
+     /K [10 0 R
+         << /Type /OBJR /Pg 11 0 R /Obj 13 0 R >>]
+  >>
+endobj
+
+10 0 obj
+   << /Type /StructElem
+      /S /Title
+      /P 9 0 R
+      /Pg 4 0 R
+      /C /C1
+      /K [15 0 R]
+   >>
+endobj
+
+11 0 obj
+  << /Type /Page
+     /Parent 3 0 R
+     /Contents 12 0 R
+     /StructParents 1
+     /Resources << /ProcSet [/PDF /Text]
+                   /Font << /F1 5 0 R >>
+                >>
+  >>
+endobj
+
+12 0 obj
+  << /Length 190 >>
+stream
+  /H1 <</MCID 1>> BDC
+  BT
+    /F1 24 Tf
+    100 700 Td
+    (Goodbye Cruel World...) Tj
+  ET
+  /P <</MCID 2>> BDC
+  BT
+    /F1 12 Tf
+    100 600 Td
+    (I'll be back shortly!) Tj
+  ET
+  EMC
+endstream
+endobj
+
+13 0 obj
+   << /Type /StructElem
+      /S /Title
+      /P 9 0 R
+      /Pg 11 0 R
+      /K [1]
+      /C /C1
+      /A << /A1 2 /A2 2 >>
+   >>
+endobj
+
+14 0 obj
+   << /Type /StructElem
+      /S /P
+      /P 7 0 R
+      /Pg 11 0 R
+      /K [2]
+      /R 1
+      % /C3 does not exist (coverage)
+      /C [/C1 0 /C2 1 /C3 1]
+      /A [<< /A1 2 /A2 2 >> 0
+          << /A2 3 >> 1]
+   >>
+endobj
+
+15 0 obj
+   <</Type /MCR /MCID 1 /Pg 4 0 R>>
+endobj
+
+xref
+0 16
+0000000000 65535 f 
+0000000009 00000 n 
+0000000116 00000 n 
+0000000172 00000 n 
+0000000280 00000 n 
+0000000481 00000 n 
+0000000581 00000 n 
+0000000721 00000 n 
+0000000990 00000 n 
+0000001090 00000 n 
+0000001247 00000 n 
+0000001372 00000 n 
+0000001575 00000 n 
+0000001819 00000 n 
+0000001967 00000 n 
+0000002204 00000 n 
+trailer  << /Size 16 /Root 1 0 R >>
+startxref
+2257
+%%EOF

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,6 +20,40 @@ def test_cli_metadata(path: Path):
     for password in passwords:
         try:
             main(["--password", password, "--non-interactive", str(path)])
+            main(["--password", password, "--non-interactive", "--outline", str(path)])
+            main(
+                ["--password", password, "--non-interactive", "--structure", str(path)]
+            )
+        except PDFPasswordIncorrect:
+            pass
+        except PDFEncryptionError:
+            pytest.skip("cryptography package not installed")
+
+
+@pytest.mark.parametrize("path", ALLPDFS, ids=str)
+def test_cli_outline(path: Path):
+    if path.name in XFAILS:
+        pytest.xfail("Intentionally corrupt file: %s" % path.name)
+    passwords = PASSWORDS.get(path.name, [""])
+    for password in passwords:
+        try:
+            main(["--password", password, "--non-interactive", "--outline", str(path)])
+        except PDFPasswordIncorrect:
+            pass
+        except PDFEncryptionError:
+            pytest.skip("cryptography package not installed")
+
+
+@pytest.mark.parametrize("path", ALLPDFS, ids=str)
+def test_cli_structure(path: Path):
+    if path.name in XFAILS:
+        pytest.xfail("Intentionally corrupt file: %s" % path.name)
+    passwords = PASSWORDS.get(path.name, [""])
+    for password in passwords:
+        try:
+            main(
+                ["--password", password, "--non-interactive", "--structure", str(path)]
+            )
         except PDFPasswordIncorrect:
             pass
         except PDFEncryptionError:


### PR DESCRIPTION
- Accept very illegal things in structure tree root, because we can (amazingly, nobody actually does this though)
- Be robust to corrupted PDFs with broken structure elements
