### PR TITLE
Improve error handling in font initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## PLAYA 0.4.2: Unreleased
 - Correct `fontsize` and `scaling` in text state
+- Correct implicit font encodings for Type1 fonts
+- More fine-grained error handling in font initialization
 
 ## PLAYA 0.4.1: 2025-03-20
 

--- a/playa/document.py
+++ b/playa/document.py
@@ -16,7 +16,6 @@ from typing import (
     Iterable,
     Iterator,
     List,
-    Mapping,
     Optional,
     Set,
     Tuple,
@@ -505,7 +504,7 @@ class Document:
             self._cached_objs[objid] = obj
         return self._cached_objs[objid]
 
-    def get_font(self, objid: object, spec: Mapping[str, object]) -> Font:
+    def get_font(self, objid: object, spec: Dict[str, PDFObject]) -> Font:
         if objid and objid in self._cached_fonts:
             return self._cached_fonts[objid]
         if spec.get("Type") is not LITERAL_FONT:

--- a/playa/document.py
+++ b/playa/document.py
@@ -85,6 +85,11 @@ log = logging.getLogger(__name__)
 LITERAL_PDF = LIT("PDF")
 LITERAL_TEXT = LIT("Text")
 LITERAL_FONT = LIT("Font")
+LITERAL_TYPE1 = LIT("Type1")
+LITERAL_MMTYPE1 = LIT("MMType1")
+LITERAL_TYPE0 = LIT("Type0")
+LITERAL_TYPE3 = LIT("Type3")
+LITERAL_TRUETYPE = LIT("TrueType")
 LITERAL_OBJSTM = LIT("ObjStm")
 LITERAL_XREF = LIT("XRef")
 LITERAL_CATALOG = LIT("Catalog")
@@ -504,40 +509,43 @@ class Document:
             self._cached_objs[objid] = obj
         return self._cached_objs[objid]
 
-    def get_font(self, objid: object, spec: Dict[str, PDFObject]) -> Font:
+    def get_font(self, objid: object, spec: Union[Dict[str, PDFObject], None]) -> Font:
         if objid and objid in self._cached_fonts:
             return self._cached_fonts[objid]
+        if spec is None:
+            self._cached_fonts[objid] = Font({}, {})
+            return self._cached_fonts[objid]
+        # Create a Font object, hopefully
+        font: Union[Font, None] = None
         if spec.get("Type") is not LITERAL_FONT:
-            log.warning("Font specification Type is not /Font: %r", spec)
-        # Create a Font object.
-        if "Subtype" in spec:
-            subtype = literal_name(spec["Subtype"])
-        else:
-            log.warning("Font specification Subtype is not specified: %r", spec)
-            subtype = ""
-        if subtype in ("Type1", "MMType1"):
-            # Type1 Font
-            font: Font = Type1Font(spec)
-        elif subtype == "TrueType":
-            # TrueType Font
+            log.warning("Font Type is not /Font: %r", spec)
+        subtype = spec.get("Subtype")
+        if subtype in (LITERAL_TYPE1, LITERAL_MMTYPE1):
+            font = Type1Font(spec)
+        elif subtype is LITERAL_TRUETYPE:
             font = TrueTypeFont(spec)
-        elif subtype == "Type3":
-            # Type3 Font
+        elif subtype == LITERAL_TYPE3:
             font = Type3Font(spec)
-        elif subtype == "Type0":
-            # Type0 Font
-            dfonts = list_value(spec["DescendantFonts"])
-            assert dfonts
-            if len(dfonts) != 1:
-                log.debug("Type 0 font should have 1 descendant, has more: %r", dfonts)
-            subspec = dict_value(dfonts[0]).copy()
-            # Merge the root and descendant font dictionaries
-            for k in ("Encoding", "ToUnicode"):
-                if k in spec:
-                    subspec[k] = resolve1(spec[k])
-            font = CIDFont(subspec)
+        elif subtype == LITERAL_TYPE0:
+            if "DescendantFonts" not in spec:
+                log.warning("Type0 font has no DescendantFonts: %r", spec)
+            else:
+                dfonts = resolve1(spec["DescendantFonts"])
+                if len(dfonts) != 1:
+                    log.debug("Type 0 font should have 1 descendant, has more: %r", dfonts)
+                subspec = resolve1(dfonts[0])
+                if not isinstance(subspec, dict):
+                    log.warning("Invalid descendant font: %r", subspec)
+                else:
+                    subspec = subspec.copy()
+                    # Merge the root and descendant font dictionaries
+                    for k in ("Encoding", "ToUnicode"):
+                        if k in spec:
+                            subspec[k] = resolve1(spec[k])
+                    font = CIDFont(subspec)
         else:
-            log.warning("Invalid Font spec, creating dummy font: %r" % spec)
+            log.warning("Unknown Subtype in font: %r" % spec)
+        if font is None:
             # We need a dummy font object to be able to do *something*
             # (even if it's the wrong thing) with text objects.
             font = Font({}, {})

--- a/playa/page.py
+++ b/playa/page.py
@@ -1343,13 +1343,12 @@ class LazyInterpreter:
                     if isinstance(spec, ObjRef):
                         objid = spec.objid
                     try:
-                        spec = dict_value(spec)
-                        self.fontmap[fontid] = doc.get_font(objid, spec)
-                    except TypeError:
+                        self.fontmap[fontid] = doc.get_font(objid, dict_value(spec))
+                    except Exception:
                         log.warning(
-                            "Broken/missing font spec for Font ID %r: %r", fontid, spec
+                            "Invalid font dictionary for Font %r: %r", fontid, spec, exc_info=True
                         )
-                        self.fontmap[fontid] = doc.get_font(objid, {})
+                        self.fontmap[fontid] = doc.get_font(objid, None)
             elif k == "ColorSpace":
                 if not isinstance(mapping, dict):
                     log.warning("ColorSpace mapping not a dict: %r", mapping)

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -70,3 +70,6 @@ def test_implicit_encoding_cff() -> None:
         for name, desc in fonts.items():
             font = doc.get_font(desc.objid, desc.resolve())
             assert font.encoding
+        # Verify fallback to StandardEncoding
+        t = page.extract_text()
+        assert t.strip() == "Part I\nClick here to access Part II \non hp.com."


### PR DESCRIPTION
We still need the catch-all for `TypeError` due to rampant use of `dict_value` and friends, but this at least covers some specific and obvious problems.

Also, some broken PDFs use a string instead of a name for `BaseFont`, so we accept that.

And, of course, confusion between `ToUnicode` and `Encoding` reigns supreme, so be tolerant of people who expected some kind of consistency from Adobe based on that bogus tech note and figured that `ToUnicode` could just be a CMap name (it is not a CMap! stop calling it one!)