### PR TITLE
Dont't split PathObject into subpaths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - BREAKING: `parent_tree` moved to `playa.structure.Tree`
 - BREAKING: `Point`, `Rect`, `Matrix` and `PDFObject` moved to
   `playa.pdftypes`
+- BREAKING: `PathObject` no longer contains "subpaths", it is safe to
+  recursively descend it now
 
 ## PLAYA 0.4.2: 2025-04-26
 - Correct `fontsize` and `scaling` in text state

--- a/playa/data/content.py
+++ b/playa/data/content.py
@@ -167,8 +167,8 @@ class Path(TypedDict, total=False):
     """True if the filling of complex paths uses the even-odd
     winding rule, False if the non-zero winding number rule is
     used (PDF 1.7 section 8.5.3.3)"""
-    components: List[List["PathSegment"]]
-    """Subpaths, each of which consists of a list of segments."""
+    segments: List["PathSegment"]
+    """Path segments."""
     gstate: "GraphicState"
     """Graphic state."""
     mcstack: List["Tag"]
@@ -325,7 +325,7 @@ def asobj_image(obj: _ImageObject) -> Image:
 
 @asobj.register
 def asobj_path(obj: _PathObject) -> Path:
-    path = Path(components=asobj([list(subpath.segments) for subpath in obj]))
+    path = Path(segments=[asobj(seg) for seg in obj.segments])
     gstate = asobj(obj.gstate)
     if gstate:
         path["gstate"] = gstate

--- a/playa/page.py
+++ b/playa/page.py
@@ -968,51 +968,9 @@ class PathObject(ContentObject):
     fill: bool
     evenodd: bool
 
-    def __len__(self):
-        """Number of subpaths."""
-        return min(1, sum(1 for seg in self.raw_segments if seg.operator == "m"))
-
-    def __iter__(self):
-        """Iterate over subpaths.
-
-        If there is only a single subpath, it will still be iterated
-        over.  This means that some care must be taken (for example,
-        checking if `len(path) == 1`) to avoid endless recursion.
-
-        Note: subpaths inherit the values of `fill` and `evenodd` from
-        the parent path, but these values are no longer meaningful
-        since the winding rules must be applied to the composite path
-        as a whole (this is not a bug, just don't rely on them to know
-        which regions are filled or not).
-
-        """
-        # FIXME: Is there an itertool or a more_itertool for this?
-        segs = []
-        for seg in self.raw_segments:
-            if seg.operator == "m" and segs:
-                yield PathObject(
-                    _pageref=self._pageref,
-                    gstate=self.gstate,
-                    ctm=self.ctm,
-                    mcstack=self.mcstack,
-                    raw_segments=segs,
-                    stroke=self.stroke,
-                    fill=self.fill,
-                    evenodd=self.evenodd,
-                )
-                segs = []
-            segs.append(seg)
-        if segs:
-            yield PathObject(
-                _pageref=self._pageref,
-                gstate=self.gstate,
-                ctm=self.ctm,
-                mcstack=self.mcstack,
-                raw_segments=segs,
-                stroke=self.stroke,
-                fill=self.fill,
-                evenodd=self.evenodd,
-            )
+    def __len__(self) -> int:
+        """Does not iterate over subpaths. Do it yourself if you must."""
+        return 0
 
     @property
     def segments(self) -> Iterator[PathSegment]:

--- a/playa/page.py
+++ b/playa/page.py
@@ -969,8 +969,8 @@ class PathObject(ContentObject):
     evenodd: bool
 
     def __len__(self) -> int:
-        """Does not iterate over subpaths. Do it yourself if you must."""
-        return 0
+        """Number of segments (beware: not subpaths!)"""
+        return len(self.raw_segments)
 
     @property
     def segments(self) -> Iterator[PathSegment]:

--- a/tests/test_lazy_api.py
+++ b/tests/test_lazy_api.py
@@ -28,8 +28,7 @@ def test_content_objects():
         assert mcs_bbox == [254.25, 895.5023, 360.09, 972.6]
         for obj in page.paths:
             assert obj.object_type == "path"
-            assert len(obj) == 1
-            assert len(list(obj)) == 1
+            assert len(obj) == 0
         rect = next(obj for obj in page.paths)
         ibbox = [round(x) for x in rect.bbox]
         assert ibbox == [85, 669, 211, 670]

--- a/tests/test_lazy_api.py
+++ b/tests/test_lazy_api.py
@@ -28,7 +28,7 @@ def test_content_objects():
         assert mcs_bbox == [254.25, 895.5023, 360.09, 972.6]
         for obj in page.paths:
             assert obj.object_type == "path"
-            assert len(obj) == 0
+            assert len(obj) != 0
         rect = next(obj for obj in page.paths)
         ibbox = [round(x) for x in rect.bbox]
         assert ibbox == [85, 669, 211, 670]


### PR DESCRIPTION
This behavior was added in https://github.com/pdfminer/pdfminer.six/commit/e83dd26671e5e6962960ee7b55aa4b8ab45e85d5 with the purpose of detecting rectangles, which is useful for rendering pdf as html. This seems out of scope for playa and adds complexity for nothing.