### PR TITLE
fix: do not follow circular xobject references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Correct `ValueError` on incorrect stream lengths for ASCII85 data
 - Correct implicit font encodings for Type1 fonts
 - More fine-grained error handling in font initialization
+- Correct infinite recursion in malicious Form XObjects
 
 ## PLAYA 0.4.1: 2025-03-20
 

--- a/playa/page.py
+++ b/playa/page.py
@@ -354,17 +354,18 @@ class Page:
     ) -> Iterator[Union[CO, "ContentObject"]]:
         """Iterate over content objects, recursing into form XObjects."""
 
-        def flatten_one(itor: Iterable["ContentObject"]) -> Iterator["ContentObject"]:
+        from typing import Set
+        def flatten_one(itor: Iterable["ContentObject"], parents: Set[str]) -> Iterator["ContentObject"]:
             for obj in itor:
-                if isinstance(obj, XObjectObject):
-                    yield from flatten_one(obj)
+                if isinstance(obj, XObjectObject) and obj.xobjid not in parents:
+                    yield from flatten_one(obj, parents | {obj.xobjid})
                 else:
                     yield obj
 
         if filter_class is None:
-            yield from flatten_one(self)
+            yield from flatten_one(self, set())
         else:
-            for obj in flatten_one(self):
+            for obj in flatten_one(self, set()):
                 if isinstance(obj, filter_class):
                     yield obj
 

--- a/playa/page.py
+++ b/playa/page.py
@@ -355,7 +355,10 @@ class Page:
         """Iterate over content objects, recursing into form XObjects."""
 
         from typing import Set
-        def flatten_one(itor: Iterable["ContentObject"], parents: Set[str]) -> Iterator["ContentObject"]:
+
+        def flatten_one(
+            itor: Iterable["ContentObject"], parents: Set[str]
+        ) -> Iterator["ContentObject"]:
             for obj in itor:
                 if isinstance(obj, XObjectObject) and obj.xobjid not in parents:
                     yield from flatten_one(obj, parents | {obj.xobjid})

--- a/samples/evil_xobjects.pdf
+++ b/samples/evil_xobjects.pdf
@@ -1,0 +1,90 @@
+%PDF-1.4
+1 0 obj
+<<
+ /Type /Catalog
+ /Outlines 2 0 R
+ /Pages 3 0 R
+>>
+endobj
+2 0 obj
+<<
+ /Type /Outlines
+ /Count 0
+>>
+endobj
+3 0 obj
+<<
+ /Type /Pages
+ /Kids [ 4 0 R ]
+ /Count 1
+>>
+endobj
+4 0 obj
+<<
+ /Type /Page
+ /Parent 3 0 R
+ /MediaBox [ 0 0 500 300 ]
+ /Contents 5 0 R
+ /Resources <<
+  /ProcSet [ /PDF /Text ]
+  /XObject << /X1 6 0 R >>
+ >>
+>>
+endobj
+5 0 obj
+<< /Length 24 >>
+stream
+1 0 0 1 25 25 cm /X1 Do
+endstream
+endobj
+6 0 obj
+<< /Subtype /Form
+   /BBox [0 0 1000 1000]
+   /Length 61
+   /Resources <<
+     /ProcSet [ /PDF /Text ]
+     /Font << /F1 7 0 R >>
+     /XObject << /X0 8 0 R >>
+   >>
+>>
+stream
+BT
+/F1 24 Tf
+(Hello world) Tj
+ET
+0.5 0 0 0.5 25 25 cm /X0 Do
+endstream
+endobj
+7 0 obj
+<<
+ /Type /Font
+ /Subtype /Type1
+ /Name /F1
+ /BaseFont /Helvetica
+ /Encoding /MacRomanEncoding
+>>
+endobj
+8 0 obj
+<< /Subtype /Form
+   /BBox [0 0 1000 1000]
+   /Length 61
+   /Resources <<
+     /ProcSet [ /PDF /Text ]
+     /Font << /F1 7 0 R >>
+     /XObject << /X1 6 0 R >>
+   >>
+>>
+stream
+BT
+/F1 24 Tf
+(Hello world) Tj
+ET
+0.5 0 0 0.5 25 25 cm /X1 Do
+endstream
+endobj
+trailer 
+<<
+ /Size 8
+ /Root 1 0 R
+>>
+%%EOF

--- a/tests/data.py
+++ b/tests/data.py
@@ -77,6 +77,8 @@ PDFMINER_BUGS = {
     "utf16_tounicode.pdf",
     "ascii_tounicode.pdf",
     "duplicate_encoding_tounicode.pdf",
+    # Except this one here where pdfminer.six will just crash
+    "evil_xobjects.pdf",
 }
 # Broken XRef tables (bogus linearization, concatenation, etc)
 FALLBACKS = {

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -202,3 +202,10 @@ def test_objects_decrypted() -> None:
         assert info.obj == doc[10]
         assert isinstance(info.obj, dict)
         assert info.obj["CreationDate"] == b"D:20140509193727+02'00'"
+
+
+def test_evil_xobjects() -> None:
+    """Verify that we do not follow circular references in XObjects."""
+    with playa.open(TESTDIR / "evil_xobjects.pdf") as doc:
+        for _ in doc.pages[0].flatten():
+            pass


### PR DESCRIPTION
Opinions differ about what to do about these (some renderers will show "hello world" 3 times, others 2) but consensus is, yeah, infinite recursion is bad.