### PR TITLE
fix!: make type annotations much stricter

### DIFF
--- a/playa/ccitt.py
+++ b/playa/ccitt.py
@@ -23,6 +23,7 @@ from typing import (
     Sequence,
     Union,
 )
+from playa.pdftypes import PDFObject
 
 
 def get_bytes(data: bytes) -> Iterator[int]:
@@ -67,7 +68,7 @@ class BitParser:
             for m in (128, 64, 32, 16, 8, 4, 2, 1):
                 self._parse_bit(byte & m)
 
-    def _parse_bit(self, x: object) -> None:
+    def _parse_bit(self, x: int) -> None:
         if x:
             v = self._state[1]
         else:
@@ -364,7 +365,7 @@ class CCITTG4Parser(BitParser):
             except EOFB:
                 break
 
-    def _parse_mode(self, mode: object) -> BitParserState:
+    def _parse_mode(self, mode: Any) -> BitParserState:
         if mode == "p":
             self._do_pass()
             self._flush_line()
@@ -566,7 +567,7 @@ class CCITTFaxDecoder(CCITTG4Parser):
         self._buf += arr.tobytes()
 
 
-def ccittfaxdecode(data: bytes, params: Dict[str, object]) -> bytes:
+def ccittfaxdecode(data: bytes, params: Dict[str, PDFObject]) -> bytes:
     from playa.pdftypes import int_value
 
     K = params.get("K")

--- a/playa/cli.py
+++ b/playa/cli.py
@@ -91,7 +91,13 @@ from playa.data.content import Image
 from playa.data.metadata import asobj_document
 from playa.outline import Outline
 from playa.page import ContentObject, ImageObject, TextObject
-from playa.pdftypes import LITERALS_DCT_DECODE, ContentStream, ObjRef, resolve1
+from playa.pdftypes import (
+    LITERALS_DCT_DECODE,
+    ContentStream,
+    ObjRef,
+    str_value,
+    PDFObject,
+)
 from playa.structure import ContentItem
 from playa.structure import ContentObject as StructContentObject
 from playa.structure import Element
@@ -214,7 +220,7 @@ def extract_stream(doc: Document, args: argparse.Namespace) -> None:
     args.outfile.buffer.write(stream.buffer)
 
 
-def resolve_many(x: object, default: object = None) -> Any:
+def resolve_many(x: PDFObject, default: PDFObject = None) -> PDFObject:
     """Resolves many indirect object references inside the given object.
 
     Because there may be circular references (and in the case of a
@@ -435,15 +441,15 @@ def _extract_element(el: Element, indent: int, outfh: TextIO) -> bool:
     if page is not None:
         format_attr("page_idx", page.page_idx)
     if "T" in el.props:
-        format_attr("title", decode_text(resolve1(el.props["T"])))
+        format_attr("title", decode_text(str_value(el.props["T"])))
     if "Lang" in el.props:
-        format_attr("language", decode_text(resolve1(el.props["Lang"])))
+        format_attr("language", decode_text(str_value(el.props["Lang"])))
     if "Alt" in el.props:
-        format_attr("alternate_description", decode_text(resolve1(el.props["Alt"])))
+        format_attr("alternate_description", decode_text(str_value(el.props["Alt"])))
     if "E" in el.props:
-        format_attr("abbreviation_expansion", decode_text(resolve1(el.props["E"])))
+        format_attr("abbreviation_expansion", decode_text(str_value(el.props["E"])))
     if "ActualText" in el.props:
-        format_attr("actual_text", decode_text(resolve1(el.props["ActualText"])))
+        format_attr("actual_text", decode_text(str_value(el.props["ActualText"])))
     print(f"{ws}{{", file=outfh)
     print(",\n".join(s), end="", file=outfh)
     print(f',\n{ws}{ss}"children": [', file=outfh)

--- a/playa/cmapdb.py
+++ b/playa/cmapdb.py
@@ -24,7 +24,6 @@ from typing import (
     Iterable,
     Iterator,
     List,
-    MutableMapping,
     Optional,
     TextIO,
     Tuple,
@@ -51,13 +50,13 @@ class CMapError(Exception):
 class CMapBase:
     debug = 0
 
-    def __init__(self, **kwargs: object) -> None:
-        self.attrs: MutableMapping[str, object] = kwargs.copy()
+    def __init__(self, **kwargs: Any) -> None:
+        self.attrs: Dict[str, Any] = kwargs.copy()
 
     def is_vertical(self) -> bool:
         return self.attrs.get("WMode", 0) != 0
 
-    def set_attr(self, k: str, v: object) -> None:
+    def set_attr(self, k: str, v: Any) -> None:
         self.attrs[k] = v
 
     def use_cmap(self, cmap: "CMapBase") -> None:

--- a/playa/data/content.py
+++ b/playa/data/content.py
@@ -28,8 +28,7 @@ from playa.page import PathSegment as _PathSegment
 from playa.page import TagObject as _TagObject
 from playa.page import TextObject as _TextObject
 from playa.page import TextState as _TextState
-from playa.pdftypes import resolve_all
-from playa.utils import MATRIX_IDENTITY, Matrix, Point, Rect
+from playa.pdftypes import resolve_all, MATRIX_IDENTITY, Matrix, Point, Rect
 
 
 class Text(TypedDict, total=False):

--- a/playa/font.py
+++ b/playa/font.py
@@ -41,6 +41,8 @@ from playa.pdftypes import (
     int_value,
     list_value,
     num_value,
+    point_value,
+    rect_value,
     resolve1,
     resolve_all,
     stream_value,
@@ -117,10 +119,14 @@ class Font:
         default_width: Optional[float] = None,
     ) -> None:
         self.descriptor = descriptor
-        self.widths = resolve_all(widths)
-        self.fontname = resolve1(descriptor.get("FontName", "unknown"))
-        if isinstance(self.fontname, PSLiteral):
-            self.fontname = literal_name(self.fontname)
+        self.widths = widths
+        fontname = resolve1(descriptor.get("FontName"))
+        if isinstance(fontname, PSLiteral):
+            self.fontname = literal_name(fontname)
+        elif isinstance(fontname, (bytes, str)):
+            self.fontname = decode_text(fontname)
+        else:
+            self.fontname = "unknown"
         self.flags = int_value(descriptor.get("Flags", 0))
         self.ascent = num_value(descriptor.get("Ascent", 0))
         self.descent = num_value(descriptor.get("Descent", 0))
@@ -129,12 +135,11 @@ class Font:
             self.default_width = num_value(descriptor.get("MissingWidth", 0))
         else:
             self.default_width = default_width
-        self.default_width = resolve1(self.default_width)
         self.leading = num_value(descriptor.get("Leading", 0))
-        self.bbox = cast(
-            Rect,
-            list_value(resolve_all(descriptor.get("FontBBox", (0, 0, 0, 0)))),
-        )
+        if "FontBBox" in descriptor:
+            self.bbox = rect_value(descriptor["FontBBox"])
+        else:
+            self.bbox = (0, 0, 0, 0)
         self.hscale = self.vscale = 0.001
 
         # PDF RM 9.8.1 specifies /Descent should always be a negative number.
@@ -268,7 +273,7 @@ class Type1Font(SimpleFont):
             firstchar = int_value(spec.get("FirstChar", 0))
             # lastchar = int_value(spec.get('LastChar', 255))
             width_list = list_value(spec.get("Widths", [0] * 256))
-            widths = {i + firstchar: resolve1(w) for (i, w) in enumerate(width_list)}
+            widths = {i + firstchar: num_value(w) for (i, w) in enumerate(width_list)}
         SimpleFont.__init__(self, descriptor, widths, spec)
 
     def get_implicit_encoding(
@@ -343,7 +348,7 @@ class TrueTypeFont(SimpleFont):
         firstchar = int_value(spec.get("FirstChar", 0))
         # lastchar = int_value(spec.get('LastChar', 255))
         width_list = list_value(spec.get("Widths", [0] * 256))
-        widths = {i + firstchar: resolve1(w) for (i, w) in enumerate(width_list)}
+        widths = {i + firstchar: num_value(w) for (i, w) in enumerate(width_list)}
         SimpleFont.__init__(self, descriptor, widths, spec)
 
     def get_implicit_encoding(
@@ -404,12 +409,16 @@ class CIDFont(Font):
         self.cidsysteminfo = dict_value(spec.get("CIDSystemInfo", {}))
         # These are *supposed* to be ASCII (PDF 1.7 section 9.7.3),
         # but for whatever reason they are sometimes UTF-16BE
-        cid_registry = decode_text(
-            resolve1(self.cidsysteminfo.get("Registry", b"unknown"))
-        )
-        cid_ordering = decode_text(
-            resolve1(self.cidsysteminfo.get("Ordering", b"unknown"))
-        )
+        cid_registry = resolve1(self.cidsysteminfo.get("Registry"))
+        if isinstance(cid_registry, (str, bytes)):
+            cid_registry = decode_text(cid_registry)
+        else:
+            cid_registry = "unknown"
+        cid_ordering = resolve1(self.cidsysteminfo.get("Ordering"))
+        if isinstance(cid_ordering, (str, bytes)):
+            cid_ordering = decode_text(cid_ordering)
+        else:
+            cid_ordering = "unknown"
         self.cidcoding = f"{cid_registry.strip()}-{cid_ordering.strip()}"
         self.cmap: CMapBase = self.get_cmap_from_spec(spec)
 
@@ -480,7 +489,12 @@ class CIDFont(Font):
             # writing mode: vertical
             widths2 = get_widths2(list_value(spec.get("W2", [])))
             self.disps = {cid: (vx, vy) for (cid, (_, (vx, vy))) in widths2.items()}
-            (vy, w) = resolve1(spec.get("DW2", [880, -1000]))
+            if "DW2" in spec:
+                (vy, w) = point_value(spec["DW2"])
+            else:
+                # FIXME: Where did these values come from?
+                vy = 880
+                w = -1000
             self.default_disp = (None, vy)
             widths = {cid: w for (cid, (w, _)) in widths2.items()}
             default_width = w
@@ -489,7 +503,10 @@ class CIDFont(Font):
             self.disps = {}
             self.default_disp = 0
             widths = get_widths(list_value(spec.get("W", [])))
-            default_width = spec.get("DW", 1000)
+            if "DW" in spec:
+                default_width = num_value(spec["DW"])
+            else:
+                default_width = 1000
         Font.__init__(self, descriptor, widths, default_width=default_width)
 
     def get_cmap_from_spec(self, spec: Dict[str, PDFObject]) -> CMapBase:
@@ -520,12 +537,16 @@ class CIDFont(Font):
         cmap_name = "unknown"  # default value
         try:
             spec_encoding = resolve1(spec["Encoding"])
-            if isinstance(spec_encoding, PSLiteral):
-                cmap_name = spec_encoding.name
+            if spec_encoding is not None:
+                cmap_name = literal_name(spec_encoding)
             else:
-                cmap_name = literal_name(spec_encoding["CMapName"])
+                spec_encoding = resolve1(spec["CMapName"])
+                if spec_encoding is not None:
+                    cmap_name = literal_name(spec_encoding)
         except KeyError:
             log.warning("Font spec is missing Encoding: %r", spec)
+        except TypeError:
+            log.warning("Font spec has invalid Encoding: %r", spec)
         return IDENTITY_ENCODER.get(cmap_name, cmap_name)
 
     def decode(self, data: bytes) -> Iterable[Tuple[int, str]]:

--- a/playa/font.py
+++ b/playa/font.py
@@ -44,13 +44,11 @@ from playa.pdftypes import (
     point_value,
     rect_value,
     resolve1,
-    resolve_all,
     stream_value,
 )
 from playa.utils import (
     Matrix,
     Point,
-    Rect,
     apply_matrix_norm,
     choplist,
     decode_text,

--- a/playa/parser.py
+++ b/playa/parser.py
@@ -23,7 +23,9 @@ from playa.pdftypes import (
     LITERALS_ASCII85_DECODE,
     LITERALS_ASCIIHEX_DECODE,
     ContentStream,
+    InlineImage,
     ObjRef,
+    PDFObject,
     PSKeyword,
     PSLiteral,
     decipher_all,
@@ -265,26 +267,6 @@ class Lexer:
         return (self._curtokenpos, b"".join(parts))
 
 
-class InlineImage(ContentStream):
-    """Specific class for inline images so the interpreter can
-    recognize them (they are otherwise the same thing as content
-    streams)."""
-
-
-PDFObject = Union[
-    str,
-    float,
-    bool,
-    PSLiteral,
-    bytes,
-    List,
-    Dict,
-    ObjRef,
-    PSKeyword,
-    InlineImage,
-    ContentStream,
-    None,
-]
 StackEntry = Tuple[int, PDFObject]
 EIR = re.compile(rb"\sEI\b")
 EIEIR = re.compile(rb"EI")

--- a/playa/pdftypes.py
+++ b/playa/pdftypes.py
@@ -238,7 +238,9 @@ def resolve_all(x: PDFObject, default: PDFObject = None) -> PDFObject:
     create circular references if they exist, so beware.
     """
 
-    def resolver(x: PDFObject, default: PDFObject, seen: Dict[int, PDFObject]) -> PDFObject:
+    def resolver(
+        x: PDFObject, default: PDFObject, seen: Dict[int, PDFObject]
+    ) -> PDFObject:
         if isinstance(x, ObjRef):
             ref = x
             while isinstance(x, ObjRef):
@@ -255,7 +257,9 @@ def resolve_all(x: PDFObject, default: PDFObject = None) -> PDFObject:
     return resolver(x, default, {})
 
 
-def decipher_all(decipher: DecipherCallable, objid: int, genno: int, x: PDFObject) -> PDFObject:
+def decipher_all(
+    decipher: DecipherCallable, objid: int, genno: int, x: PDFObject
+) -> PDFObject:
     """Recursively deciphers the given object."""
     if isinstance(x, bytes):
         if len(x) == 0:
@@ -446,6 +450,7 @@ class ContentStream:
         from playa.lzw import lzwdecode
         from playa.runlength import rldecode
         from playa.utils import apply_png_predictor, apply_tiff_predictor
+
         assert self._data is None and self.rawdata is not None, str(
             (self._data, self.rawdata),
         )

--- a/playa/pdftypes.py
+++ b/playa/pdftypes.py
@@ -16,14 +16,30 @@ from typing import (
     cast,
 )
 
-from playa.ascii85 import ascii85decode, asciihexdecode
-from playa.ccitt import ccittfaxdecode
-from playa.lzw import lzwdecode
-from playa.runlength import rldecode
-from playa.utils import apply_png_predictor, apply_tiff_predictor
 from playa.worker import DocumentRef, _deref_document
 
 logger = logging.getLogger(__name__)
+
+
+PDFObject = Union[
+    str,
+    float,
+    bool,
+    "PSLiteral",
+    bytes,
+    List,
+    Dict,
+    "ObjRef",
+    "PSKeyword",
+    "InlineImage",
+    "ContentStream",
+    None,
+]
+Point = Tuple[float, float]
+Rect = Tuple[float, float, float, float]
+Matrix = Tuple[float, float, float, float, float, float]
+BBOX_NONE = (-1, -1, -1, -1)
+MATRIX_IDENTITY: Matrix = (1, 0, 0, 1, 0, 0)
 
 
 class PSLiteral:
@@ -158,9 +174,6 @@ class DecipherCallable(Protocol):
         raise NotImplementedError
 
 
-_DEFAULT = object()
-
-
 class ObjRef:
     def __init__(
         self,
@@ -178,7 +191,7 @@ class ObjRef:
         self.doc = doc
         self.objid = objid
 
-    def __eq__(self, other: object) -> bool:
+    def __eq__(self, other: Any) -> bool:
         if not isinstance(other, ObjRef):
             raise NotImplementedError("Unimplemented comparison with non-ObjRef")
         if self.doc is None and other.doc is None:
@@ -196,7 +209,7 @@ class ObjRef:
     def __repr__(self) -> str:
         return "<ObjRef:%d>" % (self.objid)
 
-    def resolve(self, default: object = None) -> Any:
+    def resolve(self, default: Any = None) -> Any:
         if self.doc is None:
             return default
         doc = _deref_document(self.doc)
@@ -206,7 +219,7 @@ class ObjRef:
             return default
 
 
-def resolve1(x: object, default: object = None) -> Any:
+def resolve1(x: PDFObject, default: PDFObject = None) -> PDFObject:
     """Resolves an object.
 
     If this is an array or dictionary, it may still contains
@@ -217,7 +230,7 @@ def resolve1(x: object, default: object = None) -> Any:
     return x
 
 
-def resolve_all(x: object, default: object = None) -> Any:
+def resolve_all(x: PDFObject, default: PDFObject = None) -> PDFObject:
     """Resolves all indirect object references inside the given object.
 
     This creates new copies of any lists or dictionaries, so the
@@ -225,7 +238,7 @@ def resolve_all(x: object, default: object = None) -> Any:
     create circular references if they exist, so beware.
     """
 
-    def resolver(x: object, default: object, seen: Dict[int, object]) -> Any:
+    def resolver(x: PDFObject, default: PDFObject, seen: Dict[int, PDFObject]) -> PDFObject:
         if isinstance(x, ObjRef):
             ref = x
             while isinstance(x, ObjRef):
@@ -242,7 +255,7 @@ def resolve_all(x: object, default: object = None) -> Any:
     return resolver(x, default, {})
 
 
-def decipher_all(decipher: DecipherCallable, objid: int, genno: int, x: object) -> Any:
+def decipher_all(decipher: DecipherCallable, objid: int, genno: int, x: PDFObject) -> PDFObject:
     """Recursively deciphers the given object."""
     if isinstance(x, bytes):
         if len(x) == 0:
@@ -255,28 +268,28 @@ def decipher_all(decipher: DecipherCallable, objid: int, genno: int, x: object) 
     return x
 
 
-def int_value(x: object) -> int:
+def int_value(x: PDFObject) -> int:
     x = resolve1(x)
     if not isinstance(x, int):
         raise TypeError("Integer required: %r" % (x,))
     return x
 
 
-def float_value(x: object) -> float:
+def float_value(x: PDFObject) -> float:
     x = resolve1(x)
     if not isinstance(x, float):
         raise TypeError("Float required: %r" % (x,))
     return x
 
 
-def num_value(x: object) -> float:
+def num_value(x: PDFObject) -> float:
     x = resolve1(x)
     if not isinstance(x, (int, float)):  # == utils.isnumber(x)
         raise TypeError("Int or Float required: %r" % x)
     return x
 
 
-def uint_value(x: object, n_bits: int) -> int:
+def uint_value(x: PDFObject, n_bits: int) -> int:
     """Resolve number and interpret it as a two's-complement unsigned number"""
     xi = int_value(x)
     if xi > 0:
@@ -285,32 +298,62 @@ def uint_value(x: object, n_bits: int) -> int:
         return xi + cast(int, 2**n_bits)
 
 
-def str_value(x: object) -> bytes:
+def str_value(x: PDFObject) -> bytes:
     x = resolve1(x)
     if not isinstance(x, bytes):
         raise TypeError("String required: %r" % x)
     return x
 
 
-def list_value(x: object) -> Union[List[Any], Tuple[Any, ...]]:
+def list_value(x: PDFObject) -> Union[List[Any], Tuple[Any, ...]]:
     x = resolve1(x)
     if not isinstance(x, (list, tuple)):
         raise TypeError("List required: %r" % x)
     return x
 
 
-def dict_value(x: object) -> Dict[Any, Any]:
+def dict_value(x: PDFObject) -> Dict[Any, Any]:
     x = resolve1(x)
     if not isinstance(x, dict):
         raise TypeError("Dict required: %r" % x)
     return x
 
 
-def stream_value(x: object) -> "ContentStream":
+def stream_value(x: PDFObject) -> "ContentStream":
     x = resolve1(x)
     if not isinstance(x, ContentStream):
         raise TypeError("ContentStream required: %r" % x)
     return x
+
+
+def point_value(o: PDFObject) -> Point:
+    try:
+        (x, y) = (num_value(x) for x in list_value(o))
+        return x, y
+    except ValueError:
+        raise ValueError("Could not parse point %r" % (o,))
+    except TypeError:
+        raise TypeError("Point contains non-numeric values")
+
+
+def rect_value(o: PDFObject) -> Rect:
+    try:
+        (x0, y0, x1, y1) = (num_value(x) for x in list_value(o))
+        return x0, y0, x1, y1
+    except ValueError:
+        raise ValueError("Could not parse rectangle %r" % (o,))
+    except TypeError:
+        raise TypeError("Rectangle contains non-numeric values")
+
+
+def matrix_value(o: PDFObject) -> Matrix:
+    try:
+        (a, b, c, d, e, f) = (num_value(x) for x in list_value(o))
+        return a, b, c, d, e, f
+    except ValueError:
+        raise ValueError("Could not parse matrix %r" % (o,))
+    except TypeError:
+        raise TypeError("Matrix contains non-numeric values")
 
 
 def decompress_corrupted(data: bytes) -> bytes:
@@ -365,16 +408,16 @@ class ContentStream:
                 self.attrs,
             )
 
-    def __contains__(self, name: object) -> bool:
+    def __contains__(self, name: str) -> bool:
         return name in self.attrs
 
     def __getitem__(self, name: str) -> Any:
         return self.attrs[name]
 
-    def get(self, name: str, default: object = None) -> Any:
+    def get(self, name: str, default: PDFObject = None) -> PDFObject:
         return self.attrs.get(name, default)
 
-    def get_any(self, names: Iterable[str], default: object = None) -> Any:
+    def get_any(self, names: Iterable[str], default: PDFObject = None) -> PDFObject:
         for name in names:
             if name in self.attrs:
                 return self.attrs[name]
@@ -398,6 +441,11 @@ class ContentStream:
         return list(zip(resolved_filters, resolved_params))
 
     def decode(self, strict: bool = False) -> None:
+        from playa.ascii85 import ascii85decode, asciihexdecode
+        from playa.ccitt import ccittfaxdecode
+        from playa.lzw import lzwdecode
+        from playa.runlength import rldecode
+        from playa.utils import apply_png_predictor, apply_tiff_predictor
         assert self._data is None and self.rawdata is not None, str(
             (self._data, self.rawdata),
         )
@@ -493,3 +541,9 @@ class ContentStream:
             self.decode()
             assert self._data is not None
         return self._data
+
+
+class InlineImage(ContentStream):
+    """Specific class for inline images so the interpreter can
+    recognize them (they are otherwise the same thing as content
+    streams)."""

--- a/playa/structure.py
+++ b/playa/structure.py
@@ -19,19 +19,13 @@ from typing import (
 
 from playa.parser import LIT, PDFObject, PSLiteral
 from playa.pdftypes import (
-    BBOX_NONE,
-    Rect,
     ContentStream,
     ObjRef,
     dict_value,
-    int_value,
-    list_value,
     literal_name,
     resolve1,
-    rect_value,
     stream_value,
 )
-from playa.utils import get_transformed_bound
 from playa.worker import (
     DocumentRef,
     PageRef,
@@ -105,9 +99,7 @@ class ContentObject:
                 xobjid = literal_name(self.props["Name"])
             else:
                 xobjid = "XObject"
-            return XObjectObject.from_stream(
-                self.props, self.page, xobjid=xobjid
-            )
+            return XObjectObject.from_stream(self.props, self.page, xobjid=xobjid)
         objtype = self.type
         if objtype is LITERAL_ANNOT:
             from playa.page import Annotation

--- a/playa/utils.py
+++ b/playa/utils.py
@@ -1,7 +1,9 @@
 """Miscellaneous Routines."""
 
+import itertools
 import string
 from typing import (
+    Any,
     Iterable,
     Iterator,
     List,
@@ -9,6 +11,8 @@ from typing import (
     TypeVar,
     Union,
 )
+
+from playa.pdftypes import Point, Rect, Matrix
 
 # from sys import maxint as INF doesn't work anymore under Python3, but PDF
 # still uses 32 bits ints
@@ -161,15 +165,6 @@ def apply_png_predictor(
     return bytes(buf)
 
 
-Point = Tuple[float, float]
-Rect = Tuple[float, float, float, float]
-Matrix = Tuple[float, float, float, float, float, float]
-
-
-#  Matrix operations
-MATRIX_IDENTITY: Matrix = (1, 0, 0, 1, 0, 0)
-
-
 def normalize_rect(r: Rect) -> Rect:
     (x0, y0, x1, y1) = r
     if x1 < x0:
@@ -228,7 +223,7 @@ def apply_matrix_norm(m: Matrix, v: Point) -> Point:
 #  Utility functions
 
 
-def isnumber(x: object) -> bool:
+def isnumber(x: Any) -> bool:
     return isinstance(x, (int, float))
 
 
@@ -247,6 +242,17 @@ def get_bound(pts: Iterable[Point]) -> Rect:
     x1 = max(xs)
     y1 = max(ys)
     return x0, y0, x1, y1
+
+
+def get_bound_rects(boxes: Iterable[Rect]) -> Rect:
+    """Compute the union of bounding boxes (which need not be normalized)
+
+    Raises:
+      ValueError on empty input (as there is no bounding box).
+    """
+    return get_bound(
+        itertools.chain.from_iterable(((x0, y0), (x1, y1)) for x0, y0, x1, y1 in boxes)
+    )
 
 
 def get_transformed_bound(matrix: Matrix, bbox: Rect) -> Rect:

--- a/playa/xref.py
+++ b/playa/xref.py
@@ -26,6 +26,7 @@ from playa.pdftypes import (
     ContentStream,
     dict_value,
     int_value,
+    list_value,
     stream_value,
 )
 from playa.utils import (
@@ -247,7 +248,7 @@ class XRefStream:
         ):
             raise ValueError(f"Invalid PDF stream spec {stream!r}")
         size = stream["Size"]
-        index_array = stream.get("Index", (0, size))
+        index_array = list_value(stream.get("Index") or [0, size])
         if len(index_array) % 2 != 0:
             raise PDFSyntaxError("Invalid index number")
         for start, end in choplist(2, index_array):

--- a/tests/test_lazy_api.py
+++ b/tests/test_lazy_api.py
@@ -2,16 +2,13 @@
 Test the ContentObject API for pages.
 """
 
-import itertools
 from pathlib import Path
-from typing import cast
-
-import pytest
 
 import playa
+import pytest
 from playa.color import PREDEFINED_COLORSPACE, Color
 from playa.exceptions import PDFEncryptionError
-from playa.utils import Matrix, apply_matrix_pt, get_bound, get_transformed_bound
+from playa.utils import get_bound
 
 from .data import ALLPDFS, CONTRIB, PASSWORDS, TESTDIR, XFAILS
 
@@ -120,19 +117,6 @@ def test_rotated_text_objects() -> None:
                 points.append((x0, y0))
                 points.append((x1, y1))
             assert bbox == pytest.approx(get_bound(points))
-
-
-def test_rotated_bboxes() -> None:
-    """Verify that rotated bboxes are correctly calculated."""
-    points = ((0, 0), (0, 100), (100, 100), (100, 0))
-    bbox = (0, 0, 100, 100)
-    # Test all possible sorts of CTM
-    vals = (-1, -0.5, 0, 0.5, 1)
-    for matrix in itertools.product(vals, repeat=4):
-        ctm = cast(Matrix, (*matrix, 0, 0))
-        gtb = get_transformed_bound(ctm, bbox)
-        bound = get_bound((apply_matrix_pt(ctm, p) for p in points))
-        assert gtb == bound
 
 
 def test_operators_in_text() -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,16 @@
+import itertools
+from typing import cast
+from playa.utils import get_transformed_bound, get_bound, apply_matrix_pt, Matrix
+
+
+def test_rotated_bboxes() -> None:
+    """Verify that rotated bboxes are correctly calculated."""
+    points = ((0, 0), (0, 100), (100, 100), (100, 0))
+    bbox = (0, 0, 100, 100)
+    # Test all possible sorts of CTM
+    vals = (-1, -0.5, 0, 0.5, 1)
+    for matrix in itertools.product(vals, repeat=4):
+        ctm = cast(Matrix, (*matrix, 0, 0))
+        gtb = get_transformed_bound(ctm, bbox)
+        bound = get_bound((apply_matrix_pt(ctm, p) for p in points))
+        assert gtb == bound


### PR DESCRIPTION
There was a lot of incorrect use of `object` everywhere, now there isnt. Also, points, rects and matrices now are in pdftypes and have their own functions for type-checking them.