### PR TITLE
feat!: Add support for role map and standard structure types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## PLAYA 0.5.0: 2025-05-07
+- Remove use of `object` in type annotations
+- Add support for role map and standard structure types
+- Add `bbox` and `contents` to structure elements
+- BREAKING: `find` and `find_all` in structure search by standard
+  structure types (roles)
+- BREAKING: `parent_tree` moved to `playa.structure.Tree`
+- BREAKING: `Point`, `Rect`, `Matrix` and `PDFObject` moved to
+  `playa.pdftypes`
+
 ## PLAYA 0.4.2: 2025-04-26
 - Correct `fontsize` and `scaling` in text state
 - Correct `ValueError` on incorrect stream lengths for ASCII85 data

--- a/playa/__init__.py
+++ b/playa/__init__.py
@@ -34,10 +34,9 @@ from playa.page import (
     TextState,
 )
 from playa.parser import Token
-from playa.pdftypes import ContentStream, ObjRef
+from playa.pdftypes import ContentStream, Matrix, ObjRef, Point, Rect
 from playa.pdftypes import resolve1 as resolve
 from playa.pdftypes import resolve_all
-from playa.utils import Matrix, Point, Rect
 from playa.worker import _init_worker, _init_worker_buffer
 
 __all__ = [

--- a/playa/cli.py
+++ b/playa/cli.py
@@ -431,6 +431,7 @@ def _extract_element(el: Element, indent: int, outfh: TextIO) -> bool:
 
     try:
         format_attr("type", el.type)
+        format_attr("role", el.role)
     except KeyError:
         LOG.warning("Structure element with no type ignored: %r", el)
         return False

--- a/playa/data_structures.py
+++ b/playa/data_structures.py
@@ -34,7 +34,7 @@ class NumberTree:
         return walk_number_tree(self._obj)
 
     def __contains__(self, num: int) -> bool:
-        for idx, val in walk_number_tree(self._obj, num):
+        for idx, _ in walk_number_tree(self._obj, num):
             if idx == num:
                 return True
         return False

--- a/playa/page.py
+++ b/playa/page.py
@@ -42,32 +42,31 @@ from playa.font import Font
 from playa.parser import KWD, InlineImage, ObjectParser, PDFObject, Token
 from playa.pdftypes import (
     BBOX_NONE,
-    MATRIX_IDENTITY,
-    Matrix,
-    Point,
-    Rect,
     LIT,
+    MATRIX_IDENTITY,
     ContentStream,
+    Matrix,
     ObjRef,
+    Point,
     PSKeyword,
     PSLiteral,
+    Rect,
     dict_value,
     int_value,
     list_value,
     literal_name,
     matrix_value,
     num_value,
-    rect_value,
-    resolve1,
-    stream_value,
+    rect_value
 )
+from playa.pdftypes import resolve1, stream_value
 from playa.utils import (
     apply_matrix_pt,
     decode_text,
     get_bound,
-    transform_bbox,
     mult_matrix,
     normalize_rect,
+    transform_bbox,
 )
 from playa.worker import PageRef, _deref_document, _deref_page, _ref_document, _ref_page
 
@@ -75,6 +74,10 @@ if TYPE_CHECKING:
     from playa.document import Document
 
 log = logging.getLogger(__name__)
+
+# some aliases for backwards compatibility
+parse_rect = rect_value
+get_transformed_bound = transform_bbox
 
 # some predefined literals and keywords.
 LITERAL_PAGE = LIT("Page")

--- a/playa/page.py
+++ b/playa/page.py
@@ -57,7 +57,7 @@ from playa.pdftypes import (
     literal_name,
     matrix_value,
     num_value,
-    rect_value
+    rect_value,
 )
 from playa.pdftypes import resolve1, stream_value
 from playa.utils import (

--- a/playa/page.py
+++ b/playa/page.py
@@ -376,7 +376,7 @@ class Page:
         prev_end = 0.0
         lines = []
         strings = []
-        for text in self.flatten(TextObject):
+        for text in self.texts:
             line_matrix = text.textstate.line_matrix
             vertical = (
                 False if text.textstate.font is None else text.textstate.font.vertical
@@ -408,7 +408,7 @@ class Page:
         strings: List[str] = []
         at_mcs: Union[MarkedContent, None] = None
         prev_mcid: Union[int, None] = None
-        for text in self.flatten(TextObject):
+        for text in self.texts:
             in_artifact = same_actual_text = reversed_chars = False
             actual_text = None
             for mcs in reversed(text.mcstack):
@@ -1325,10 +1325,6 @@ def make_seg(operator: PathOperator, *points: Point):
     return PathSegment(operator, points)
 
 
-def point_value(x: PDFObject, y: PDFObject) -> Point:
-    return (num_value(x), num_value(y))
-
-
 class LazyInterpreter:
     """Interpret the page yielding lazy objects."""
 
@@ -1749,11 +1745,11 @@ class LazyInterpreter:
 
     def do_m(self, x: PDFObject, y: PDFObject) -> None:
         """Begin new subpath"""
-        self.curpath.append(make_seg("m", point_value(x, y)))
+        self.curpath.append(make_seg("m", (num_value(x), num_value(y))))
 
     def do_l(self, x: PDFObject, y: PDFObject) -> None:
         """Append straight line segment to path"""
-        self.curpath.append(make_seg("l", point_value(x, y)))
+        self.curpath.append(make_seg("l", (num_value(x), num_value(y))))
 
     def do_c(
         self,
@@ -1768,9 +1764,9 @@ class LazyInterpreter:
         self.curpath.append(
             make_seg(
                 "c",
-                point_value(x1, y1),
-                point_value(x2, y2),
-                point_value(x3, y3),
+                (num_value(x1), num_value(y1)),
+                (num_value(x2), num_value(y2)),
+                (num_value(x3), num_value(y3)),
             ),
         )
 
@@ -1779,8 +1775,8 @@ class LazyInterpreter:
         self.curpath.append(
             make_seg(
                 "v",
-                point_value(x2, y2),
-                point_value(x3, y3),
+                (num_value(x2), num_value(y2)),
+                (num_value(x3), num_value(y3)),
             )
         )
 
@@ -1789,8 +1785,8 @@ class LazyInterpreter:
         self.curpath.append(
             make_seg(
                 "y",
-                point_value(x1, y1),
-                point_value(x3, y3),
+                (num_value(x1), num_value(y1)),
+                (num_value(x3), num_value(y3)),
             )
         )
 
@@ -1804,10 +1800,10 @@ class LazyInterpreter:
         y = num_value(y)
         w = num_value(w)
         h = num_value(h)
-        self.curpath.append(make_seg("m", point_value(x, y)))
-        self.curpath.append(make_seg("l", point_value(x + w, y)))
-        self.curpath.append(make_seg("l", point_value(x + w, y + h)))
-        self.curpath.append(make_seg("l", point_value(x, y + h)))
+        self.curpath.append(make_seg("m", (x, y)))
+        self.curpath.append(make_seg("l", (x + w, y)))
+        self.curpath.append(make_seg("l", (x + w, y + h)))
+        self.curpath.append(make_seg("l", (x, y + h)))
         self.curpath.append(make_seg("h"))
 
     def do_n(self) -> None:

--- a/playa/page.py
+++ b/playa/page.py
@@ -65,7 +65,7 @@ from playa.utils import (
     apply_matrix_pt,
     decode_text,
     get_bound,
-    get_transformed_bound,
+    transform_bbox,
     mult_matrix,
     normalize_rect,
 )
@@ -841,7 +841,7 @@ class ImageObject(ContentObject):
         # unit high in user space, regardless of the number of samples
         # in the image. To be painted, an image shall be mapped to a
         # region of the page by temporarily altering the CTM.
-        return get_transformed_bound(self.ctm, (0, 0, 1, 1))
+        return transform_bbox(self.ctm, (0, 0, 1, 1))
 
 
 @dataclass
@@ -885,7 +885,7 @@ class XObjectObject(ContentObject):
         if "BBox" not in self.stream:
             log.debug("XObject %r has no BBox: %r", self.xobjid, self.stream)
             return self.page.cropbox
-        return get_transformed_bound(self.ctm, rect_value(self.stream["BBox"]))
+        return transform_bbox(self.ctm, rect_value(self.stream["BBox"]))
 
     @property
     def buffer(self) -> bytes:
@@ -1031,7 +1031,7 @@ class PathObject(ContentObject):
             itertools.chain.from_iterable(seg.points for seg in self.raw_segments)
         )
         # Transform it and get the new bounding box
-        return get_transformed_bound(self.ctm, bbox)
+        return transform_bbox(self.ctm, bbox)
 
 
 @dataclass
@@ -1283,7 +1283,7 @@ class TextObject(ContentObject):
         if self._bbox is not None:
             return self._bbox
         matrix = mult_matrix(self.textstate.line_matrix, self.ctm)
-        self._bbox = get_transformed_bound(matrix, self.text_space_bbox)
+        self._bbox = transform_bbox(matrix, self.text_space_bbox)
         return self._bbox
 
     @property

--- a/playa/structure.py
+++ b/playa/structure.py
@@ -19,13 +19,17 @@ from typing import (
 
 from playa.parser import LIT, PDFObject, PSLiteral
 from playa.pdftypes import (
+    BBOX_NONE,
     ContentStream,
     ObjRef,
+    Rect,
     dict_value,
     literal_name,
     resolve1,
+    rect_value,
     stream_value,
 )
+from playa.utils import transform_bbox
 from playa.worker import (
     DocumentRef,
     PageRef,
@@ -267,7 +271,7 @@ class Element(Findable):
             return BBOX_NONE
         if "BBox" in self.props:
             rawbox = rect_value(self.props["BBox"])
-            return get_transformed_bound(page.ctm, rawbox)
+            return transform_bbox(page.ctm, rawbox)
         else:
             pass
 

--- a/playa/structure.py
+++ b/playa/structure.py
@@ -129,11 +129,14 @@ class ContentObject:
 
 def _find_all(
     elements: List["Element"],
-    matcher: Union[str, Pattern[str], MatchFunc],
+    matcher: Union[str, Pattern[str], MatchFunc, None] = None,
 ) -> Iterator["Element"]:
     """
     Common code for `find_all()` in trees and elements.
     """
+
+    def match_all(_: "Element") -> bool:
+        return True
 
     def match_tag(x: "Element") -> bool:
         """Match an element name."""
@@ -143,7 +146,9 @@ def _find_all(
         """Match an element name by regular expression."""
         return matcher.match(x.type)  # type: ignore
 
-    if isinstance(matcher, str):
+    if matcher is None:
+        match_func = match_all
+    elif isinstance(matcher, str):
         match_func = match_tag
     elif isinstance(matcher, re.Pattern):
         match_func = match_regex
@@ -164,24 +169,26 @@ class Findable(Iterable):
     repeating oneself"""
 
     def find_all(
-        self, matcher: Union[str, Pattern[str], MatchFunc]
+        self, matcher: Union[str, Pattern[str], MatchFunc, None] = None
     ) -> Iterator["Element"]:
         """Iterate depth-first over matching elements in subtree.
 
         The `matcher` argument is either an element name, a regular
-        expression, or a function taking a `Element` and
-        returning `True` if the element matches.
+        expression, or a function taking a `Element` and returning
+        `True` if the element matches, or `None` (default) to return
+        all descendants in depth-first order.
         """
         return _find_all(list(self), matcher)
 
     def find(
-        self, matcher: Union[str, Pattern[str], MatchFunc]
+        self, matcher: Union[str, Pattern[str], MatchFunc, None] = None
     ) -> Union["Element", None]:
         """Find the first matching element in subtree.
 
         The `matcher` argument is either an element name, a regular
-        expression, or a function taking a `Element` and
-        returning `True` if the element matches.
+        expression, or a function taking a `Element` and returning
+        `True` if the element matches, or `None` (default) to just get
+        the first child element.
         """
         try:
             return next(_find_all(list(self), matcher))

--- a/playa/structure.py
+++ b/playa/structure.py
@@ -29,7 +29,7 @@ from playa.pdftypes import (
     rect_value,
     stream_value,
 )
-from playa.utils import transform_bbox
+from playa.utils import transform_bbox, get_bound_rects
 from playa.worker import (
     DocumentRef,
     PageRef,
@@ -273,7 +273,13 @@ class Element(Findable):
             rawbox = rect_value(self.props["BBox"])
             return transform_bbox(page.ctm, rawbox)
         else:
-            pass
+            # NOTE: This is probably somewhat slow
+            mcids = set(item.mcid
+                        for item in self.contents
+                        if item.page is None or item.page is page)
+            return get_bound_rects(obj.bbox
+                                   for obj in page
+                                   if obj.mcid in mcids)
 
     def __iter__(self) -> Iterator[Union["Element", ContentItem, ContentObject]]:
         if "K" in self.props:

--- a/playa/structure.py
+++ b/playa/structure.py
@@ -141,11 +141,11 @@ def _find_all(
 
     def match_tag(x: "Element") -> bool:
         """Match an element name."""
-        return x.type == matcher
+        return x.role == matcher
 
     def match_regex(x: "Element") -> bool:
         """Match an element name by regular expression."""
-        return matcher.match(x.type)  # type: ignore
+        return matcher.match(x.role)  # type: ignore
 
     if matcher is None:
         match_func = match_all
@@ -170,14 +170,21 @@ class Findable(Iterable):
     repeating oneself"""
 
     def find_all(
-        self, matcher: Union[str, Pattern[str], MatchFunc, None] = None
+            self, matcher: Union[str, Pattern[str], MatchFunc, None] = None
     ) -> Iterator["Element"]:
         """Iterate depth-first over matching elements in subtree.
 
-        The `matcher` argument is either an element name, a regular
+        The `matcher` argument is either a string, a regular
         expression, or a function taking a `Element` and returning
         `True` if the element matches, or `None` (default) to return
         all descendants in depth-first order.
+
+        For compatibility with `pdfplumber` and consistent behaviour
+        across documents, names and regular expressions are matched
+        against the `role` attribute.  If you wish to match the "raw"
+        structure type from the `type` attribute, you can do this with
+        a matching function.
+
         """
         return _find_all(list(self), matcher)
 
@@ -186,10 +193,12 @@ class Findable(Iterable):
     ) -> Union["Element", None]:
         """Find the first matching element in subtree.
 
-        The `matcher` argument is either an element name, a regular
-        expression, or a function taking a `Element` and returning
-        `True` if the element matches, or `None` (default) to just get
-        the first child element.
+        The `matcher` argument is either a string or a regular
+        expression to be matched against the `role` attribute, or a
+        function taking a `Element` and returning `True` if the
+        element matches, or `None` (default) to just get the first
+        child element.
+
         """
         try:
             return next(_find_all(list(self), matcher))

--- a/playa/utils.py
+++ b/playa/utils.py
@@ -255,7 +255,7 @@ def get_bound_rects(boxes: Iterable[Rect]) -> Rect:
     )
 
 
-def get_transformed_bound(matrix: Matrix, bbox: Rect) -> Rect:
+def transform_bbox(matrix: Matrix, bbox: Rect) -> Rect:
     """Transform a bounding box and return the rectangle that covers
     the points of the resulting shape."""
     x0, y0, x1, y1 = bbox

--- a/playa/utils.py
+++ b/playa/utils.py
@@ -2,6 +2,7 @@
 
 import itertools
 import string
+import warnings
 from typing import (
     Any,
     Iterable,
@@ -275,6 +276,18 @@ def transform_bbox(matrix: Matrix, bbox: Rect) -> Rect:
             apply_matrix_pt(matrix, (x1, y1)),
         )
     )
+
+
+def get_transformed_bound(matrix: Matrix, bbox: Rect) -> Rect:
+    """Deprecated name for transform_bbox.
+
+    Danger: Deprecated
+        This function is deprecated and will be removed in
+        PLAYA-PDF 1.0.
+    """
+    warnings.warn("get_transformed_bound is deprecated, please use"
+                  "transform_bbox instead now.", DeprecationWarning)
+    return transform_bbox(matrix, bbox)
 
 
 def choplist(n: int, seq: Iterable[_T]) -> Iterator[Tuple[_T, ...]]:

--- a/playa/utils.py
+++ b/playa/utils.py
@@ -285,8 +285,10 @@ def get_transformed_bound(matrix: Matrix, bbox: Rect) -> Rect:
         This function is deprecated and will be removed in
         PLAYA-PDF 1.0.
     """
-    warnings.warn("get_transformed_bound is deprecated, please use"
-                  "transform_bbox instead now.", DeprecationWarning)
+    warnings.warn(
+        "get_transformed_bound is deprecated, please use" "transform_bbox instead now.",
+        DeprecationWarning,
+    )
     return transform_bbox(matrix, bbox)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ exclude = ["samples/3rdparty"] # why no leading slash?
 
 [tool.pytest.ini_options]
 testpaths = [ "tests" ]
+markers = [ "contrib", "thirdparty" ]
 
 [tool.hatch.envs.hatch-test]
 extra-dependencies = [ "cryptography", "pdfminer.six" ]

--- a/tests/data.py
+++ b/tests/data.py
@@ -5,6 +5,8 @@ Lists of data files and directories to be shared by various tests.
 import json
 from pathlib import Path
 
+import pytest
+
 TESTDIR = Path(__file__).parent.parent / "samples"
 SUBDIRS = ["acroform", "encryption", "scancode"]
 BASEPDFS = list(TESTDIR.glob("*.pdf"))
@@ -12,12 +14,17 @@ for name in SUBDIRS:
     BASEPDFS.extend((TESTDIR / name).glob("*.pdf"))
 CONTRIB = TESTDIR / "contrib"
 if CONTRIB.exists():
-    BASEPDFS.extend(CONTRIB.glob("*.pdf"))
+    BASEPDFS.extend(
+        pytest.param(path, marks=pytest.mark.contrib) for path in CONTRIB.glob("*.pdf")
+    )
 
 ALLPDFS = list(BASEPDFS)
 PLUMBERS = TESTDIR / "3rdparty" / "pdfplumber" / "tests" / "pdfs"
 if PLUMBERS.exists():
-    ALLPDFS.extend(PLUMBERS.glob("*.pdf"))
+    ALLPDFS.extend(
+        pytest.param(path, marks=pytest.mark.thirdparty)
+        for path in PLUMBERS.glob("*.pdf")
+    )
 PDFJS = TESTDIR / "3rdparty" / "pdf.js" / "test"
 try:
     with open(PDFJS / "test_manifest.json", encoding="utf-8") as infh:
@@ -29,7 +36,7 @@ try:
             continue
         seen.add(entry["file"])
         if path.exists():
-            ALLPDFS.append(path)
+            ALLPDFS.append(pytest.param(path, marks=pytest.mark.thirdparty))
 except FileNotFoundError:
     pass
 

--- a/tests/data.py
+++ b/tests/data.py
@@ -10,15 +10,15 @@ import pytest
 TESTDIR = Path(__file__).parent.parent / "samples"
 SUBDIRS = ["acroform", "encryption", "scancode"]
 BASEPDFS = list(TESTDIR.glob("*.pdf"))
+ALLPDFS = [pytest.param(path) for path in BASEPDFS]
 for name in SUBDIRS:
-    BASEPDFS.extend((TESTDIR / name).glob("*.pdf"))
+    ALLPDFS.extend(pytest.param(path) for path in (TESTDIR / name).glob("*.pdf"))
 CONTRIB = TESTDIR / "contrib"
 if CONTRIB.exists():
-    BASEPDFS.extend(
+    ALLPDFS.extend(
         pytest.param(path, marks=pytest.mark.contrib) for path in CONTRIB.glob("*.pdf")
     )
 
-ALLPDFS = list(BASEPDFS)
 PLUMBERS = TESTDIR / "3rdparty" / "pdfplumber" / "tests" / "pdfs"
 if PLUMBERS.exists():
     ALLPDFS.extend(

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -21,6 +21,10 @@ def test_specific_structure():
         assert len(list(lis[0].find_all())) == 2
         assert lis[0].find().type == "LBody"
         assert lis[0].find().find().type == "Text body"
+        assert lis[0].find().find().role == "P"
+        p = pdf.structure.find("P")
+        assert p is not None
+        assert p.role == "P"
         table = pdf.structure.find("Table")
         assert table
         assert playa.asobj(table)["type"] == "Table"

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -85,5 +85,17 @@ def test_content_xobjects() -> None:
         assert mcs.mcid == 1
 
 
+def test_structure_bbox() -> None:
+    """Verify that we can get the bounding box of structure elements."""
+    with playa.open(TESTDIR / "pdf_structure.pdf") as pdf:
+        table = pdf.structure.find("Table")
+        print(table.bbox)
+        li = pdf.structure.find("LI")
+        print(li.bbox)
+    with playa.open(TESTDIR / "image_structure.pdf") as pdf:
+        figure = pdf.structure.find("Figure")
+        print(figure.bbox)
+
+
 if __name__ == "__main__":
     test_specific_structure()

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -18,6 +18,9 @@ def test_specific_structure():
         lis = list(pdf.structure.find_all("LI"))
         assert len(lis) == 4
         assert playa.asobj(lis[0])["type"] == "LI"
+        assert len(list(lis[0].find_all())) == 2
+        assert lis[0].find().type == "LBody"
+        assert lis[0].find().find().type == "Text body"
         table = pdf.structure.find("Table")
         assert table
         assert playa.asobj(table)["type"] == "Table"

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -91,12 +91,17 @@ def test_content_xobjects() -> None:
 def test_structure_bbox() -> None:
     """Verify that we can get the bounding box of structure elements."""
     with playa.open(TESTDIR / "pdf_structure.pdf") as pdf:
+        assert pdf.structure is not None
         table = pdf.structure.find("Table")
+        assert table is not None
         print(table.bbox)
         li = pdf.structure.find("LI")
+        assert li is not None
         print(li.bbox)
     with playa.open(TESTDIR / "image_structure.pdf") as pdf:
+        assert pdf.structure is not None
         figure = pdf.structure.find("Figure")
+        assert figure is not None
         print(figure.bbox)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import itertools
 from typing import cast
-from playa.utils import get_transformed_bound, get_bound, apply_matrix_pt, Matrix
+from playa.utils import transform_bbox, get_bound, apply_matrix_pt, Matrix
 
 
 def test_rotated_bboxes() -> None:
@@ -11,6 +11,5 @@ def test_rotated_bboxes() -> None:
     vals = (-1, -0.5, 0, 0.5, 1)
     for matrix in itertools.product(vals, repeat=4):
         ctm = cast(Matrix, (*matrix, 0, 0))
-        gtb = get_transformed_bound(ctm, bbox)
         bound = get_bound((apply_matrix_pt(ctm, p) for p in points))
-        assert gtb == bound
+        assert transform_bbox(ctm, bbox) == bound


### PR DESCRIPTION
BREAKING CHANGE as the `find` and `find_all` now refer to roles (as they do in `pdfplumber`)

Fixes: #97 