### PR TITLE
refactor!: most of text state is just graphics state

### DIFF
--- a/playa/data/content.py
+++ b/playa/data/content.py
@@ -53,25 +53,6 @@ class TextState(TypedDict, total=False):
     glyph_offset: Point
     """Offset of text object in relation to current line, in default text
     space units, default if not present is (0, 0)."""
-    font: Font
-    """Descriptor of current font."""
-    fontsize: float
-    """Font size in unscaled text space units (**not** in points, can be
-    scaled using `line_matrix` to obtain user space units), default if
-    not present is 1.0."""
-    charspace: float
-    """Character spacing in unscaled text space units, default if not present is 0."""
-    wordspace: float
-    """Word spacing in unscaled text space units, default if not present is 0."""
-    scaling: float
-    """Horizontal scaling factor multiplied by 100, default if not present is 100."""
-    leading: float
-    """Leading in unscaled text space units, default if not present is 0."""
-    render_mode: int
-    """Text rendering mode (PDF 1.7 Table 106), default if not present is 0."""
-    rise: float
-    """Text rise (for super and subscript) in unscaled text space
-    units, default if not present is 0."""
 
 
 class GraphicState(TypedDict, total=False):
@@ -98,6 +79,25 @@ class GraphicState(TypedDict, total=False):
     """Colour used for non-stroking operations, default black `((0,) None)`"""
     ncs: "ColorSpace"
     """Colour space used for non-stroking operations, default `DeviceGray`"""
+    font: Font
+    """Descriptor of current font."""
+    fontsize: float
+    """Font size in unscaled text space units (**not** in points, can be
+    scaled using `line_matrix` to obtain user space units), default if
+    not present is 1.0."""
+    charspace: float
+    """Character spacing in unscaled text space units, default if not present is 0."""
+    wordspace: float
+    """Word spacing in unscaled text space units, default if not present is 0."""
+    scaling: float
+    """Horizontal scaling factor multiplied by 100, default if not present is 100."""
+    leading: float
+    """Leading in unscaled text space units, default if not present is 0."""
+    render_mode: int
+    """Text rendering mode (PDF 1.7 Table 106), default if not present is 0."""
+    rise: float
+    """Text rise (for super and subscript) in unscaled text space
+    units, default if not present is 0."""
 
 
 class DashPattern(TypedDict, total=False):
@@ -203,18 +203,9 @@ class Glyph(TypedDict, total=False):
 
 @asobj.register
 def asobj_textstate(obj: _TextState) -> TextState:
-    assert obj.font is not None
-    tstate = TextState(font=asobj(obj.font), line_matrix=obj.line_matrix)
+    tstate = TextState(line_matrix=obj.line_matrix)
     if obj.glyph_offset != (0, 0):
         tstate["glyph_offset"] = obj.glyph_offset
-    if obj.fontsize != 1:
-        tstate["fontsize"] = obj.fontsize
-    if obj.scaling != 100:
-        tstate["scaling"] = obj.scaling
-    for attr in "charspace", "wordspace", "leading", "render_mode", "rise":
-        val = getattr(obj, attr, 0)
-        if val:
-            tstate[attr] = val
     return tstate
 
 
@@ -260,6 +251,11 @@ def asobj_gstate(obj: _GraphicState) -> GraphicState:
         "scs",
         "ncolor",
         "ncs",
+        "charspace",
+        "wordspace",
+        "leading",
+        "render_mode",
+        "rise",
     ):
         val = getattr(obj, field)
         if val != GRAPHICSTATE_DEFAULTS[field]:

--- a/playa/interp.py
+++ b/playa/interp.py
@@ -83,6 +83,8 @@ class LazyInterpreter:
         contents: Iterable[PDFObject],
         resources: Union[Dict, None] = None,
         filter_class: Union[Type[ContentObject], None] = None,
+        ctm: Union[Matrix, None] = None,
+        gstate: Union[GraphicState, None] = None,
     ) -> None:
         self._dispatch: Dict[PSKeyword, Tuple[Callable, int]] = {}
         for name in dir(self):
@@ -100,7 +102,7 @@ class LazyInterpreter:
         self.contents = contents
         self.filter_class = filter_class
         self.init_resources(page, page.resources if resources is None else resources)
-        self.init_state(page.ctm)
+        self.init_state(page.ctm if ctm is None else ctm, gstate)
 
     def init_resources(self, page: "Page", resources: Dict) -> None:
         """Prepare the fonts and XObjects listed in the Resource attribute."""
@@ -153,13 +155,10 @@ class LazyInterpreter:
                 for xobjid, xobjstrm in mapping.items():
                     self.xobjmap[xobjid] = xobjstrm
 
-    def init_state(self, ctm: Matrix) -> None:
-        """Initialize the text and graphic states for rendering a page."""
-        # gstack: stack for graphical states.
-        self.gstack: List[Tuple[Matrix, TextState, GraphicState]] = []
+    def init_state(self, ctm: Matrix, gstate: Union[GraphicState, None] = None) -> None:
+        self.gstack: List[Tuple[Matrix, GraphicState]] = []
         self.ctm = ctm
-        self.textstate = TextState()
-        self.graphicstate = GraphicState()
+        self.graphicstate = GraphicState() if gstate is None else copy(gstate)
         self.curpath: List[PathSegment] = []
         # argstack: stack for command arguments.
         self.argstack: List[PDFObject] = []
@@ -175,15 +174,6 @@ class LazyInterpreter:
         x = self.argstack[-n:]
         self.argstack = self.argstack[:-n]
         return x
-
-    def get_current_state(self) -> Tuple[Matrix, TextState, GraphicState]:
-        return (self.ctm, copy(self.textstate), copy(self.graphicstate))
-
-    def set_current_state(
-        self,
-        state: Tuple[Matrix, TextState, GraphicState],
-    ) -> None:
-        (self.ctm, self.textstate, self.graphicstate) = state
 
     def __iter__(self) -> Iterator[ContentObject]:
         parser = ContentParser(self.contents)
@@ -400,18 +390,23 @@ class LazyInterpreter:
         if subtype is LITERAL_FORM:
             if self.filter_class is None or self.filter_class is XObjectObject:
                 # PDF Ref 1.7, # 4.9
-                # When the Do operator is applied to a form XObject, it does the following tasks:
+                #
+                # When the Do operator is applied to a form XObject,
+                # it does the following tasks:
+                #
                 # 1. Saves the current graphics state, as if by invoking the q operator
                 # ...
                 # 5. Restores the saved graphics state, as if by invoking the Q operator
-                ctm, tstate, gstate = self.get_current_state()
+                #
+                # The lazy interpretation of this is, obviously, that
+                # we simply create an XObjectObject with a copy of the
+                # current graphics state.
                 return XObjectObject.from_stream(
                     stream=xobj,
                     page=self.page,
                     xobjid=xobjid,
-                    ctm=ctm,
-                    textstate=tstate,
-                    gstate=gstate,
+                    ctm=self.ctm,
+                    gstate=self.graphicstate,
                     mcstack=self.mcstack,
                 )
         elif subtype is LITERAL_IMAGE:
@@ -444,12 +439,12 @@ class LazyInterpreter:
 
     def do_q(self) -> None:
         """Save graphics state"""
-        self.gstack.append(self.get_current_state())
+        self.gstack.append((self.ctm, copy(self.graphicstate)))
 
     def do_Q(self) -> None:
         """Restore graphics state"""
         if self.gstack:
-            self.set_current_state(self.gstack.pop())
+            (self.ctm, self.graphicstate) = self.gstack.pop()
 
     def do_cm(
         self,
@@ -653,7 +648,7 @@ class LazyInterpreter:
         the identity matrix. Text objects cannot be nested; a second BT cannot
         appear before an ET.
         """
-        self.textstate.reset()
+        self.textstate = TextState()
 
     def do_ET(self) -> None:
         """End a text object"""
@@ -672,7 +667,7 @@ class LazyInterpreter:
 
         :param space: a number expressed in unscaled text space units.
         """
-        self.textstate.charspace = num_value(space)
+        self.graphicstate.charspace = num_value(space)
 
     def do_Tw(self, space: PDFObject) -> None:
         """Set the word spacing.
@@ -681,14 +676,14 @@ class LazyInterpreter:
 
         :param space: a number expressed in unscaled text space units
         """
-        self.textstate.wordspace = num_value(space)
+        self.graphicstate.wordspace = num_value(space)
 
     def do_Tz(self, scale: PDFObject) -> None:
         """Set the horizontal scaling.
 
         :param scale: is a number specifying the percentage of the normal width
         """
-        self.textstate.scaling = num_value(scale)
+        self.graphicstate.scaling = num_value(scale)
 
     def do_TL(self, leading: PDFObject) -> None:
         """Set the text leading.
@@ -697,7 +692,7 @@ class LazyInterpreter:
 
         :param leading: a number expressed in unscaled text space units
         """
-        self.textstate.leading = num_value(leading)
+        self.graphicstate.leading = num_value(leading)
 
     def do_Tf(self, fontid: PDFObject, fontsize: PDFObject) -> None:
         """Set the text font
@@ -707,26 +702,23 @@ class LazyInterpreter:
         :param fontsize: size is a number representing a scale factor.
         """
         try:
-            self.textstate.font = self.fontmap[literal_name(fontid)]
+            self.graphicstate.font = self.fontmap[literal_name(fontid)]
         except KeyError:
             log.warning("Undefined Font id: %r", fontid)
             doc = _deref_document(self.page.docref)
-            self.textstate.font = doc.get_font()
-        self.textstate.fontsize = num_value(fontsize)
-        self.textstate.descent = (
-            self.textstate.font.get_descent() * self.textstate.fontsize
-        )
+            self.graphicstate.font = doc.get_font()
+        self.graphicstate.fontsize = num_value(fontsize)
 
     def do_Tr(self, render: PDFObject) -> None:
         """Set the text rendering mode"""
-        self.textstate.render_mode = int_value(render)
+        self.graphicstate.render_mode = int_value(render)
 
     def do_Ts(self, rise: PDFObject) -> None:
         """Set the text rise
 
         :param rise: a number expressed in unscaled text space units
         """
-        self.textstate.rise = num_value(rise)
+        self.graphicstate.rise = num_value(rise)
 
     def do_Td(self, tx: PDFObject, ty: PDFObject) -> None:
         """Move to the start of the next line
@@ -785,8 +777,8 @@ class LazyInterpreter:
             b,
             c,
             d,
-            -self.textstate.leading * c + e,
-            -self.textstate.leading * d + f,
+            -self.graphicstate.leading * c + e,
+            -self.graphicstate.leading * d + f,
         )
         self.textstate.glyph_offset = (0, 0)
 

--- a/playa/page.py
+++ b/playa/page.py
@@ -347,7 +347,7 @@ class Page:
         for text in self.texts:
             line_matrix = text.textstate.line_matrix
             vertical = (
-                False if text.textstate.font is None else text.textstate.font.vertical
+                False if text.gstate.font is None else text.gstate.font.vertical
             )
             lpos = -2 if vertical else -1
             if (

--- a/playa/structure.py
+++ b/playa/structure.py
@@ -110,7 +110,6 @@ class ContentObject:
                 page=self.page,
                 xobjid=xobjid,
                 gstate=GraphicState(),
-                textstate=TextState(),
                 ctm=MATRIX_IDENTITY,
                 mcstack=(),
             )

--- a/samples/graphics_state_in_text_object.pdf
+++ b/samples/graphics_state_in_text_object.pdf
@@ -1,4 +1,4 @@
-%PDF-1.4
+%PDF-2.0
 1 0 obj
 <<
  /Type /Catalog
@@ -32,11 +32,21 @@ endobj
 >>
 endobj
 5 0 obj
-<< /Length 187 >>
+<< /Length 1138 >>
 stream
+% This is invalid and leads to undefined behaviour.  We follow pdf.js
+% which tolerates it and updates the text matrix anyway, thus "Hello
+% world" below is at the top left of the page.
+0 375 Td
+
 q
 BT
 /F1 24 Tf
+
+% Because BT resets (does not save/restore) the text matrix, this
+% will be at the origin.
+(foo) Tj
+
 50 100 Td
 (A) Tj
 1.5 0 0 1.5 0 0 cm
@@ -45,12 +55,36 @@ BT
 1.5 0 0 1.5 0 0 cm
 0.25 0.25 0.75 rg
 (C) Tj
-ET
-BT
+q
+10 10 Td
 Q
-/F1 24 Tf
-120 120 Td
+
+% In PDF 2.0, this should be to the *right* of "C" since
+% the text matrix is saved/restored by q/Q
+(D) Tj
+
+ET
+
+% This is invalid and leads to undefined behaviour, but we follow
+% other implementations and persist the text matrix outside BT/ET
+(BAR) Tj
+
+BT
+% Likewise, the text matrix is reset by BT, so this is at the origin
+% (but big, and blue)
+(FOO) Tj
+
+10 10 Td
 0.75 0.25 0.75 rg
+
+% This is invalid in PDF 2.0 and leads to undefined behaviour.  Does
+% it undo the Td operator above?  How about the rg (and cm, etc)?  We
+% follow pdf.js which will tolerate it and restore the previous text
+% matrix (thus "Hello World" is at the top left of the page)
+Q
+
+/F1 24 Tf
+0.25 0.75 0.25 rg
 (Hello World) Tj
 ET
 endstream

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -215,4 +215,4 @@ def test_xobject_graphicstate() -> None:
     """Verify that XObjects inherits the graphicstate of its surrounding."""
     with playa.open(TESTDIR / "xobject_graphicstate.pdf") as doc:
         text = next(doc.pages[0].texts)
-        assert text.textstate.font is not None
+        assert text.gstate.font is not None


### PR DESCRIPTION
As in some other cases it seems that the pdfminer.six authors were reading the PDF specification a bit too literally, or not literally enough, because there is no earthly reason why most of what was in the `TextState` should not just have gone in the graphics state, aside from the fact that these parameters are described in a different chapter (which is admittedly a bit confusing).  Anyway, the important part is (PDF 2.0 section 9.3.1):

> The text state operators may appear outside text objects, and the values they set are retained across
text objects in a single content stream. Like other graphics state parameters, these parameters shall be
initialised to their default values at the beginning of each page.

It isn't explicitly specified that these parameters get pushed and popped with the `q` and `Q` operators which is an imprecision in the standard that should be corrected, but it seems pretty obvious that they should be.

On the other hand, it is (finally) clarified in the PDF 2.0 errata that the "mutable" text state (which is just the line matrix and glyph offset) will get pushed and popped as well in the case that `q` and `Q` are found inside a `BT` / `ET` pair.  Poppler (at least some versions) doesn't do this correctly so you may see discrepancies with it.