### PR TITLE
Correct documentation and metadata for font, text, and glyph objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - BREAKING: Text state no longer exists in the public API, text and
   glyph objects have immutable line matrix and glyph offset now, and
   everything else is in the graphic state
+- BREAKING: `text_space_` properties are removed since what they
+  returned was not actually text space (and maybe not useful either)
 
 ## PLAYA 0.4.2: 2025-04-26
 - Correct `fontsize` and `scaling` in text state

--- a/playa/data/content.py
+++ b/playa/data/content.py
@@ -41,8 +41,7 @@ class Text(TypedDict, total=False):
     line_matrix: Matrix
     """Coordinate transformation matrix for start of current line."""
     glyph_offset: Point
-    """Offset of text object in relation to current line, in default text
-    space units, default if not present is (0, 0)."""
+    """Offset of text object in relation to current line FIXME in weird units."""
     gstate: "GraphicState"
     """Graphic state."""
     mcstack: List["Tag"]
@@ -188,8 +187,7 @@ class Glyph(TypedDict, total=False):
     """Coordinate transformation matrix, default if not present is the
     identity matrix `[1 0 0 1 0 0]`."""
     glyph_offset: Point
-    """Offset of glyph in relation to current line, in default text
-    space units, default if not present is (0, 0)."""
+    """Offset of glyph in relation to current line FIXME in weird units."""
     gstate: "GraphicState"
     """Graphic state."""
     mcstack: List["Tag"]
@@ -226,6 +224,10 @@ GRAPHICSTATE_DEFAULTS = {f.name: f.default for f in dataclasses.fields(_GraphicS
 @asobj.register
 def asobj_gstate(obj: _GraphicState) -> GraphicState:
     gstate = GraphicState()
+    if obj.font is not None:
+        gstate["font"] = asobj(obj.font)
+        # fontsize is always defined with font
+        gstate["fontsize"] = obj.fontsize
     for field in (
         "linewidth",
         "linecap",
@@ -277,7 +279,7 @@ def asobj_text(obj: _TextObject) -> Text:
     if obj.ctm is not MATRIX_IDENTITY:
         text["ctm"] = obj.ctm
     if obj.line_matrix is not MATRIX_IDENTITY:
-        text["line_matrix"] = obj.ctm
+        text["line_matrix"] = obj.line_matrix
     if obj.glyph_offset != (0, 0):
         text["glyph_offset"] = obj.glyph_offset
     return text

--- a/playa/font.py
+++ b/playa/font.py
@@ -104,8 +104,8 @@ LITERAL_STANDARD_ENCODING = LIT("StandardEncoding")
 
 
 class Font:
-    vertical = False
-    multibyte = False
+    vertical: bool = False
+    multibyte: bool = False
     encoding: Dict[int, str]
 
     def __init__(
@@ -164,12 +164,14 @@ class Font:
         return self.descent * self.vscale
 
     def get_width(self) -> float:
+        """Maximum width of a glyph in this font"""
         w = self.bbox[2] - self.bbox[0]
         if w == 0:
             w = -self.default_width
         return w * self.hscale
 
     def get_height(self) -> float:
+        """Maximum height of a glyph in this font"""
         h = self.bbox[3] - self.bbox[1]
         if h == 0:
             h = self.ascent - self.descent

--- a/samples/text_space.pdf
+++ b/samples/text_space.pdf
@@ -1,0 +1,67 @@
+%PDF-1.4
+1 0 obj
+<<
+ /Type /Catalog
+ /Outlines 2 0 R
+ /Pages 3 0 R
+>>
+endobj
+2 0 obj
+<<
+ /Type /Outlines
+ /Count 0
+>>
+endobj
+3 0 obj
+<<
+ /Type /Pages
+ /Kids [ 4 0 R ]
+ /Count 1
+>>
+endobj
+4 0 obj
+<<
+ /Type /Page
+ /Parent 3 0 R
+ /MediaBox [ 0 0 600 300 ]
+ /Contents 5 0 R
+ /Resources <<
+  /ProcSet 6 0 R
+  /Font << /F1 7 0 R >>
+ >>
+>>
+endobj
+5 0 obj
+<< /Length 0 >>
+stream
+BT
+1 0 0 1 10 100 Tm
+/F1 10 Tf
+(FOO) Tj
+1 -0.1 0.1 1 100 100 Tm
+/F1 100 Tf
+(BAR) Tj
+250 0 Td
+(BAZ) Tj
+ET
+endstream
+endobj
+6 0 obj
+[ /PDF /Text ]
+endobj
+7 0 obj
+<<
+ /Type /Font
+ /Subtype /Type1
+ /Name /F1
+ /BaseFont /Helvetica
+ /Encoding /MacRomanEncoding
+>>
+endobj
+
+trailer 
+<<
+ /Size 8
+ /Root 1 0 R
+>>
+%%EOF


### PR DESCRIPTION
This isn't complete but it at least isn't blatantly wrong anymore.

BREAKING CHANGE: `text_space_bbox` no longer exists because it isn't actually text space