### PR TITLE
feat!: Improve text extraction and add useful glyph and text properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Remove use of `object` in type annotations
 - Add support for role map and standard structure types
 - Add `bbox` and `contents` to structure elements
+- Somewhat improve untagged text extraction where the CTM is exotic
 - BREAKING: `find` and `find_all` in structure search by standard
   structure types (roles)
 - BREAKING: `parent_tree` moved to `playa.structure.Tree`
@@ -11,11 +12,13 @@
   recursively descend it now
 - BREAKING: Content objects moved to `playa.content` and interpreter
   to `playa.interp`
-- BREAKING: Text state no longer exists in the public API, text and
-  glyph objects have immutable line matrix and glyph offset now, and
+- BREAKING: Text state no longer exists in the public API, text
+  objects have immutable line matrix and glyph offset now, and
   everything else is in the graphic state
 - BREAKING: `text_space_` properties are removed since what they
   returned was not actually text space (and maybe not useful either)
+- BREAKING: `glyph_offset` is removed from glyphs and made private in
+  text objects, as it is not in a well defined space.
 
 ## PLAYA 0.4.3: 2025-05-09
 - Correct ascent, descent, and glyph boxes for Type3 fonts

--- a/benchmarks/text.py
+++ b/benchmarks/text.py
@@ -8,11 +8,14 @@ from pathlib import Path
 
 import playa
 
+SAMPLES = Path(__file__).parent.parent / "samples"
 CONTRIB = Path(__file__).parent.parent / "samples" / "contrib"
 
 LOG = logging.getLogger("benchmark-text")
 # Use a standard benchmark set to make version comparisons possible
 PDFS = [
+    "jo.pdf",
+    "zen_of_python_corrupted.pdf",
     "2023-04-06-ODJ et Résolutions-séance xtra 6 avril 2023.pdf",
     "2023-06-20-PV.pdf",
     "PSC_Station.pdf",
@@ -38,11 +41,14 @@ def benchmark_text(path: Path):
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.ERROR)
     niter = 5
     chars_time = text_time = 0.0
     for iter in range(niter + 1):
         for name in PDFS:
-            path = CONTRIB / name
+            path = SAMPLES / name
+            if not path.exists():
+                path = CONTRIB / name
             start = time.time()
             benchmark_chars(path)
             if iter != 0:

--- a/playa/content.py
+++ b/playa/content.py
@@ -519,7 +519,7 @@ class GlyphObject(ContentObject):
         if self.font.vertical:
             return c * self._displacement, d * self._displacement
         else:
-            return a * self._displacement, c * self._displacement
+            return a * self._displacement, b * self._displacement
 
     @property
     def bbox(self) -> Rect:

--- a/playa/data/content.py
+++ b/playa/data/content.py
@@ -31,16 +31,13 @@ from playa.pdftypes import resolve_all, MATRIX_IDENTITY, Matrix, Point, Rect
 
 
 class Text(TypedDict, total=False):
-    ctm: Matrix
-    """Coordinate transformation matrix, default is `(1, 0, 0, 1, 0, 0)`"""
     chars: str
     """Unicode string representation of text."""
     bbox: Rect
     """Bounding rectangle for all glyphs in text in default user space."""
-    line_matrix: Matrix
-    """Coordinate transformation matrix for start of current line."""
-    glyph_offset: Point
-    """Offset of text object in relation to current line FIXME in weird units."""
+    matrix: Matrix
+    """Text rendering matrix.  Note that the effective font size
+    and the origin can be derived from this."""
     gstate: "GraphicState"
     """Graphic state."""
     mcstack: List["Tag"]
@@ -271,6 +268,7 @@ def asobj_text(obj: _TextObject) -> Text:
     text = Text(
         chars=obj.chars,
         bbox=obj.bbox,
+        matrix=obj.matrix,
     )
     gstate = asobj(obj.gstate)
     if gstate:
@@ -278,12 +276,6 @@ def asobj_text(obj: _TextObject) -> Text:
     mcstack = [asobj(mcs) for mcs in obj.mcstack]
     if mcstack:
         text["mcstack"] = mcstack
-    if obj.ctm is not MATRIX_IDENTITY:
-        text["ctm"] = obj.ctm
-    if obj.line_matrix is not MATRIX_IDENTITY:
-        text["line_matrix"] = obj.line_matrix
-    if obj.glyph_offset != (0, 0):
-        text["glyph_offset"] = obj.glyph_offset
     return text
 
 

--- a/playa/data/content.py
+++ b/playa/data/content.py
@@ -31,13 +31,12 @@ from playa.pdftypes import resolve_all, MATRIX_IDENTITY, Matrix, Point, Rect
 
 
 class Text(TypedDict, total=False):
+    ctm: Matrix
+    """Coordinate transformation matrix, default is `(1, 0, 0, 1, 0, 0)`"""
     chars: str
     """Unicode string representation of text."""
     bbox: Rect
     """Bounding rectangle for all glyphs in text in default user space."""
-    ctm: Matrix
-    """Coordinate transformation matrix, default if not present is the
-    identity matrix `[1 0 0 1 0 0]`."""
     line_matrix: Matrix
     """Coordinate transformation matrix for start of current line."""
     glyph_offset: Point
@@ -75,9 +74,9 @@ class GraphicState(TypedDict, total=False):
     font: Font
     """Descriptor of current font."""
     fontsize: float
-    """Font size in unscaled text space units (**not** in points, can be
-    scaled using `line_matrix` to obtain user space units), default if
-    not present is 1.0."""
+    """Font size in unscaled text space units (**not** in points, can
+    be scaled using a text or glyph's `matrix` to obtain user space
+    units), default if not present is 1.0."""
     charspace: float
     """Character spacing in unscaled text space units, default if not present is 0."""
     wordspace: float
@@ -135,10 +134,12 @@ class Tag(TypedDict, total=False):
 
 
 class Image(TypedDict, total=False):
+    ctm: Matrix
+    """Coordinate transformation matrix, default is `(1, 0, 0, 1, 0, 0)`"""
     xobject_name: str
     """Name of XObject in page resources, if any."""
     bbox: Rect
-    """Bounding rectangle for image in default user space."""
+    """Bounding rectangle for image."""
     srcsize: Tuple[int, int]
     """Size of source image in pixels."""
     bits: int
@@ -152,6 +153,8 @@ class Image(TypedDict, total=False):
 
 
 class Path(TypedDict, total=False):
+    ctm: Matrix
+    """Coordinate transformation matrix, default is `(1, 0, 0, 1, 0, 0)`"""
     stroke: bool
     """True if the outline of the path is stroked."""
     fill: bool
@@ -173,7 +176,7 @@ class PathSegment(TypedDict, total=False):
     """Normalized path operator (PDF 1.7 section 8.5.2).  Note that "re"
     will be expanded into its constituent line segments."""
     points: List[Point]
-    """Point or control points in default user space for path segment."""
+    """Point or control points for path segment."""
 
 
 class Glyph(TypedDict, total=False):
@@ -182,12 +185,12 @@ class Glyph(TypedDict, total=False):
     cid: int
     """Character ID for glyph in font."""
     bbox: Rect
-    """Bounding rectangle for all glyphs in text in default user space."""
-    ctm: Matrix
-    """Coordinate transformation matrix, default if not present is the
-    identity matrix `[1 0 0 1 0 0]`."""
-    glyph_offset: Point
-    """Offset of glyph in relation to current line FIXME in weird units."""
+    """Bounding rectangle."""
+    matrix: Matrix
+    """Rendering matrix for glyph.  Note that the effective font size
+    and the origin can be derived from this."""
+    displacement: Point
+    """Displacement to origin of next glyph."""
     gstate: "GraphicState"
     """Graphic state."""
     mcstack: List["Tag"]
@@ -269,7 +272,6 @@ def asobj_text(obj: _TextObject) -> Text:
         chars=obj.chars,
         bbox=obj.bbox,
     )
-    # But there is a default graphic state
     gstate = asobj(obj.gstate)
     if gstate:
         text["gstate"] = gstate
@@ -299,6 +301,8 @@ def asobj_tag(obj: _TagObject) -> Tag:
 @asobj.register
 def asobj_image(obj: _ImageObject) -> Image:
     img = Image(srcsize=obj.srcsize, bbox=obj.bbox, stream=asobj(obj.stream))
+    if obj.ctm is not MATRIX_IDENTITY:
+        img["ctm"] = obj.ctm
     if obj.xobjid is not None:
         img["xobject_name"] = obj.xobjid
     if obj.bits != 1:
@@ -316,6 +320,8 @@ def asobj_path(obj: _PathObject) -> Path:
     gstate = asobj(obj.gstate)
     if gstate:
         path["gstate"] = gstate
+    if obj.ctm is not MATRIX_IDENTITY:
+        path["ctm"] = obj.ctm
     mcstack = [asobj(mcs) for mcs in obj.mcstack]
     if mcstack:
         path["mcstack"] = mcstack
@@ -339,6 +345,8 @@ def asobj_glyph(obj: _GlyphObject) -> Glyph:
     glyph = Glyph(
         cid=obj.cid,
         bbox=obj.bbox,
+        matrix=obj.matrix,
+        displacement=obj.displacement,
     )
     # But there is a default graphic state
     gstate = asobj(obj.gstate)
@@ -349,8 +357,4 @@ def asobj_glyph(obj: _GlyphObject) -> Glyph:
     mcstack = [asobj(mcs) for mcs in obj.mcstack]
     if mcstack:
         glyph["mcstack"] = mcstack
-    if obj.ctm is not MATRIX_IDENTITY:
-        glyph["ctm"] = obj.ctm
-    if obj.glyph_offset != (0, 0):
-        glyph["glyph_offset"] = obj.glyph_offset
     return glyph

--- a/playa/font.py
+++ b/playa/font.py
@@ -186,12 +186,27 @@ class Font:
             return self.default_width * self.hscale
         return self.widths[cid] * self.hscale
 
-    def char_disp(self, cid: int) -> Union[float, Tuple[float, float]]:
-        """Returns an integer for horizontal fonts, a tuple for vertical fonts."""
-        return 0
-
     def string_width(self, s: bytes) -> float:
         return sum(self.char_width(cid) for cid, _ in self.decode(s))
+
+    def vdisp(self, cid: int) -> float:
+        """Get vertical displacement for vertical writing mode, in
+        text space units.
+
+        This is always 0 for simple fonts as they have no vertical
+        writing mode.
+
+        """
+        return 0
+
+    def position(self, cid: int) -> Tuple[float, float]:
+        """Get position vector for vertical writing mode, in text
+        space units.
+
+        This is always `[0 0]` for simple fonts as they have no
+        vertical writing mode.
+        """
+        return (0, 0)
 
     def char_bbox(self, cid: int) -> Rect:
         """Get the standard bounding box for a character from its CID.

--- a/playa/interp.py
+++ b/playa/interp.py
@@ -245,7 +245,7 @@ class LazyInterpreter:
                     if co is not None:
                         yield co
                     if isinstance(co, TextObject):
-                        self.textstate.glyph_offset = co.next_glyph_offset
+                        self.textstate.glyph_offset = co._get_next_glyph_offset()
                 else:
                     # TODO: This can get very verbose
                     log.warning("Unknown operator: %r", obj)
@@ -371,7 +371,7 @@ class LazyInterpreter:
         obj = self.create(
             TextObject,
             line_matrix=self.textstate.line_matrix,
-            glyph_offset=self.textstate.glyph_offset,
+            _glyph_offset=self.textstate.glyph_offset,
             args=args,
         )
         if obj is not None:
@@ -379,7 +379,7 @@ class LazyInterpreter:
                 return obj
             # Even without text, TJ can still update the glyph offset
             assert isinstance(obj, TextObject)
-            self.textstate.glyph_offset = obj.next_glyph_offset
+            self.textstate.glyph_offset = obj._get_next_glyph_offset()
         return None
 
     def do_Tj(self, s: PDFObject) -> Union[ContentObject, None]:

--- a/playa/page.py
+++ b/playa/page.py
@@ -338,14 +338,15 @@ class Page:
             chars: List[str] = []
             prev_end = 0.0
             for glyph in obj:
-                x, y = glyph.glyph_offset
+                x, y = glyph.origin
                 off = y if vertical else x
                 # FIXME: The 0.5 is a heuristic!!!
                 if prev_end and off - prev_end > 0.5:
                     chars.append(" ")
                 if glyph.text is not None:
                     chars.append(glyph.text)
-                prev_end = off + glyph.adv
+                dx, dy = glyph.displacement
+                prev_end = off + (dy if vertical else dx)
             return "".join(chars), prev_end
 
         prev_end = prev_line_offset = prev_word_offset = 0.0

--- a/playa/page.py
+++ b/playa/page.py
@@ -351,11 +351,13 @@ class Page:
         lines = []
         strings = []
         for text in self.texts:
+            if text.gstate.font is None:
+                continue
+            vertical = text.gstate.font.vertical
             # Track changes to the translation component of text
             # rendering matrix to (yes, heuristically) detect newlines
             # and spaces between text objects
             _, _, _, _, dx, dy = mult_matrix(text.line_matrix, text.ctm)
-            vertical = False if text.gstate.font is None else text.gstate.font.vertical
             line_offset = dx if vertical else dy
             word_offset = dy if vertical else dx
             # Vertical text (usually) means right-to-left lines

--- a/playa/page.py
+++ b/playa/page.py
@@ -335,7 +335,7 @@ class Page:
             obj: "TextObject", vertical: bool
         ) -> Tuple[str, float]:
             """Try to get text from a text object."""
-            chars = []
+            chars: List[str] = []
             prev_end = 0.0
             for glyph in obj:
                 x, y = glyph.glyph_offset
@@ -350,7 +350,7 @@ class Page:
 
         prev_end = prev_line_offset = prev_word_offset = 0.0
         lines = []
-        strings = []
+        strings: List[str] = []
         for text in self.texts:
             if text.gstate.font is None:
                 continue

--- a/playa/page.py
+++ b/playa/page.py
@@ -359,7 +359,7 @@ class Page:
             # Track changes to the translation component of text
             # rendering matrix to (yes, heuristically) detect newlines
             # and spaces between text objects
-            _, _, _, _, dx, dy = mult_matrix(text.line_matrix, text.ctm)
+            _, _, _, _, dx, dy = text.matrix
             line_offset = dx if vertical else dy
             word_offset = dy if vertical else dx
             # Vertical text (usually) means right-to-left lines

--- a/tests/test_lazy_api.py
+++ b/tests/test_lazy_api.py
@@ -208,3 +208,23 @@ def test_glyph_bboxes() -> None:
         _, en_y0, _, en_y1 = t.bbox
         assert en_y0 <= zh_y0
         assert en_y1 >= zh_y1
+
+
+def test_glyph_properties() -> None:
+    """Check that the newfangled glyph properties do what they should."""
+    # Ensure that origin and displacement reflect actual positions
+    for space in "default", "page", "screen":
+        with playa.open(TESTDIR / "rotated.pdf", space=space) as pdf:
+            for text in pdf.pages[0].texts:
+                next_origin = text.origin
+                for glyph in text:
+                    assert glyph.origin == pytest.approx(next_origin)
+                    gx, gy = glyph.origin
+                    dx, dy = glyph.displacement
+                    next_origin = (gx + dx, gy + dy)
+        with playa.open(
+            TESTDIR / "graphics_state_in_text_object.pdf", space=space
+        ) as pdf:
+            for text in pdf.pages[0].texts:
+                x0, y0, x1, y1 = text.bbox
+                assert text.size >= y1 - y0


### PR DESCRIPTION
BREAKING CHANGE: `glyph_offset` property has been removed from the public API, as it was not enormously useful, for the following reasons:

- Real-world PDFs generally do not use the line matrix properly, or abuse it in various ways, such that it is useless for detecting line breaks, *and* the current glyph's relationship to it (which is `glyph_offset`) is not useful for this purpose either.
- Because scaling and fontsize can change through the course of a `BT`/`ET` pair, `glyph_offset` must be represented in so-called "unscaled text space units", which are a confusing and ill-defined concept.  In any case it may not have any immediately obvious relationship to the visual arrangement of glyphs on the page due to subsequent transformations.

Instead, it's possible to efficiently look at the origin and displacement vector for a glyph *in device space*, which are probably more relevant to text extraction and analysis.
