### PR TITLE
feat: support PDF 2.0 inline images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add `origin` and `displacement` to glyphs
 - Add `size` to glyphs and texts to get effective font size (still not
   entirely accurate when there is rotation or skewing)
+- Support PDF 2.0 `Length` attribute on inline images
 - BREAKING: `find` and `find_all` in structure search by standard
   structure types (roles)
 - BREAKING: `parent_tree` moved to `playa.structure.Tree`

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -20,10 +20,12 @@
 
 ::: playa.content
 
-::: playa.parser
-
 ::: playa.structure
 
 ::: playa.outline
+
+::: playa.font
+
+::: playa.parser
 
 ::: playa.worker

--- a/playa/font.py
+++ b/playa/font.py
@@ -1,3 +1,9 @@
+"""Font metrics and descriptors
+
+Danger: API subject to change.
+    These APIs are unstable and subject to revision before PLAYA 1.0.
+"""
+
 import logging
 from io import BytesIO
 from typing import (

--- a/tests/test_object_parser.py
+++ b/tests/test_object_parser.py
@@ -339,6 +339,17 @@ def test_objects():
 
 
 INLINEDATA1 = b"""
+BI /L 42 ID
+012345678901234567890123456789012345678901
+EI
+BI /Length 30 /Filter /A85 ID
+
+
+<^BVT:K:=9<E)pd;BS_1:/aSV;ag~>
+
+
+
+EI
 BI
 /Foo (bar)
 ID
@@ -378,6 +389,12 @@ OLDMACDONALDEIEIOEI
 
 def test_inline_images():
     parser = ObjectParser(INLINEDATA1)
+    pos, img = next(parser)
+    assert isinstance(img, InlineImage)
+    assert img.buffer == b"012345678901234567890123456789012345678901"
+    pos, img = next(parser)
+    assert isinstance(img, InlineImage)
+    assert img.buffer == b"VARIOUS UTTER NONSENSE"
     pos, img = next(parser)
     assert isinstance(img, InlineImage)
     assert img.attrs["Foo"] == b"bar"


### PR DESCRIPTION
This *also* fixes some dumb but rare bugs in normal inline images, like we did not accept "Filter" as well as its abbreviation "F".

Fixes: #103 