### PR TITLE
feat: add fonts property (fixes: #86)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add `size` to glyphs and texts to get effective font size (still not
   entirely accurate when there is rotation or skewing)
 - Support PDF 2.0 `Length` attribute on inline images
+- Add `font` property to documents and pages
 - BREAKING: `find` and `find_all` in structure search by standard
   structure types (roles)
 - BREAKING: `parent_tree` moved to `playa.structure.Tree`

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -90,6 +90,25 @@ def test_object_streams():
         assert len(objs) == 53
 
 
+def test_fonts():
+    """Test getting fonts from documents."""
+    with playa.open(TESTDIR / "font-size-test.pdf") as doc:
+        assert doc.fonts.keys() == {
+            "OKXWSQ+Calibri-Light",
+            "FMIXLV+Calibri-Italic",
+            "XXGPLK+Calibri-Bold",
+            "TKMFIM+Calibri-BoldItalic",
+            "XQOVTX+Calibri-LightItalic",
+            "BKHCKV+Calibri",
+            "FXOQDS+ArialMT",
+            "BAOYBE+Batang",
+        }
+    with playa.open(TESTDIR / "font-size-test.pdf") as doc:
+        assert doc.pages[0].fonts.keys() == {"TT2", "TT8", "TT10", "TT12", "TT6", "TT4"}
+        assert doc.pages[1].fonts.keys() == {"TT2", "TT14"}
+        assert doc.pages[2].fonts.keys() == {"TT2", "TT16"}
+
+
 @pytest.mark.skipif(not CONTRIB.exists(), reason="contrib samples not present")
 def test_page_labels():
     with playa.open(CONTRIB / "pagelabels.pdf") as doc:


### PR DESCRIPTION
Some caveats in that this is not lazy and may become lazy in the near future.  Using `Mapping` for the type annotation and adding a big fat warning to deter people from thinking it will always be a dict.