### PR TITLE
Fixes and improvements to text extraction, marked content and logical structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@
 - Descend into Form XObjects in `Page.xobjects`
 - Improve text extraction for rotated pages
 - Improve text extraction for tagged PDFs
-- TODO: Add functioning `__iter__` to `GlyphObject` in the case of
-  Type3 fonts, which works like `XObjectObject`
 - Correct displacement and bbox for Type3 fonts with non-diagonal
   `FontMatrix`
 - BREAKING: Remove misleading `char_width`, `get_descent`, and
@@ -17,6 +15,10 @@
   objects
 - BREAKING: Do not guess `basename` for Type3 fonts (generally it
   isn't different from `fontname` for other subset fonts)
+- BREAKING: `Element.contents` contains both `structure.ContentItem`
+  and `structure.ContentObject`
+- TODO: Add functioning `__iter__` to `GlyphObject` in the case of
+  Type3 fonts, which works like `XObjectObject`
 - TODO: Add `displacement` property to `TextObject`
 - TODO: Extract non-JPEG images as PPM
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,10 @@
 
 - Add `structure` to `Page` to access structure elements indexed by
   marked content IDs (convenience wrapper over the parent tree)
-- TODO: Add `structure` to `XObjectObject` for the same reason
-- TODO: Add `element` to all `ContentObject` to access parent
-  structure element (if any) via the parent tree
+- Add `structure` to `XObjectObject` for the same reason
+- Add `parent` to all `ContentObject` to access parent structure
+  element (if any) via the parent tree
 - Descend into Form XObjects in `Page.xobjects`
-- Add `marked_contents` iterator to `Page`
-- TODO: Add `marked_contents` to `XObjectObject` to access marked
-  content sections inside Form XObjects
 - Improve text extraction for rotated pages
 - Improve text extraction for tagged PDFs
 - TODO: Add functioning `__iter__` to `GlyphObject` in the case of

--- a/benchmarks/structure.py
+++ b/benchmarks/structure.py
@@ -24,6 +24,7 @@ PDFS = [
 
 def benchmark_cli(path: Path) -> None:
     from argparse import Namespace
+
     with open("/dev/null", "w") as out:
         args = Namespace(outfile=out)
         with playa.open(path) as doc:

--- a/playa/cli.py
+++ b/playa/cli.py
@@ -359,26 +359,6 @@ def extract_text(doc: Document, args: argparse.Namespace) -> None:
         print(text, file=args.outfile)
 
 
-@functools.lru_cache(maxsize=16)
-def get_mcid_text(pageref: PageRef) -> Dict[int, List[str]]:
-    """Get text for all MCIDs on a page"""
-    page = _deref_page(pageref)
-    mctext: Dict[int, List[str]] = {}
-    for text in page.texts:
-        mcs = text.mcs
-        if mcs is None or mcs.mcid is None:
-            continue
-        if "ActualText" in mcs.props:
-            assert isinstance(mcs.props["ActualText"], bytes)
-            chars = mcs.props["ActualText"].decode("UTF-16")
-        else:
-            chars = text.chars
-        # Remove soft hyphens
-        chars = chars.replace("\xad", "")
-        mctext.setdefault(mcs.mcid, []).append(chars)
-    return mctext
-
-
 @functools.singledispatch
 def _extract_child(
     kid: Union[Element, StructContentObject, ContentItem], indent: int, outfh: TextIO
@@ -400,11 +380,11 @@ def _extract_content_object(
 def _extract_content_item(kid: ContentItem, indent: int, outfh: TextIO) -> bool:
     if kid.page is None:
         return False
-    strs = get_mcid_text(kid.page.pageref).get(kid.mcid)
-    if strs is None:
+    text = kid.text
+    if text is None:
         return False
     ws = " " * indent
-    text = json.dumps("".join(strs), ensure_ascii=False)
+    text = json.dumps(text, ensure_ascii=False)
     print(f"{ws}{text}", end="", file=outfh)
     return True
 

--- a/playa/cli.py
+++ b/playa/cli.py
@@ -83,7 +83,7 @@ import json
 import logging
 from collections import deque
 from pathlib import Path
-from typing import Any, Deque, Dict, Iterable, Iterator, List, TextIO, Tuple, Union
+from typing import Any, Deque, Iterable, Iterator, List, TextIO, Tuple, Union
 
 import playa
 from playa import Document, Page, PDFPasswordIncorrect, asobj
@@ -102,7 +102,6 @@ from playa.structure import ContentItem
 from playa.structure import ContentObject as StructContentObject
 from playa.structure import Element
 from playa.utils import decode_text
-from playa.worker import PageRef, _deref_page
 
 LOG = logging.getLogger(__name__)
 

--- a/playa/content.py
+++ b/playa/content.py
@@ -274,31 +274,43 @@ class ContentObject:
         for a structure content item nested within it though
         non-structural marked-content shall be allowed.
         """
+        if hasattr(self, "_mcid"):
+            return self._mcid
         for mcs in self.mcstack[::-1]:
             if mcs.mcid is not None:
-                return mcs.mcid
-        return None
+                self._mcid: Union[int, None] = mcs.mcid
+                break
+        else:
+            self._mcid = None
+        return self._mcid
 
     @property
     def parent(self) -> Union["Element", None]:
         """The enclosing logical structure element, if any."""
         # Use `mcid` and not `mcs` here (see docs for `mcid`)
+        if hasattr(self, "_parent"):
+            return self._parent
         mcid = self.mcid
         if mcid is None:
+            self._parent: Union["Element", None] = None
             return None
         # FIXME: The parent ID can also come from a Form XObject
         # (either as StructParents or StructParent)
         page = self.page
         if page is None:
+            self._parent = None
             return None
         parents = page.structure
         if parents is None:
+            self._parent = None
             return None
         if mcid >= len(parents):
             log.warning("Invalid marked content ID: %d (page has %d MCIDs)",
                         mcid, len(parents))
+            self._parent = None
             return None
-        return parents[mcid]
+        self._parent = parents[mcid]
+        return self._parent
 
     @property
     def page(self) -> "Page":

--- a/playa/content.py
+++ b/playa/content.py
@@ -159,7 +159,6 @@ class GraphicState:
         model (sec. 9.3.8)
 
     """
-
     clipping_path: None = None  # TODO
     linewidth: float = 1
     linecap: int = 0

--- a/playa/interp.py
+++ b/playa/interp.py
@@ -487,7 +487,7 @@ class LazyInterpreter:
             colorspace=colorspace,
         )
         # Override parent key if one is defined on the image specifically
-        if "StructParent" in stream:
+        if obj is not None and "StructParent" in stream:
             obj._parentkey = int_value(stream["StructParent"])
         return obj
 

--- a/playa/interp.py
+++ b/playa/interp.py
@@ -472,6 +472,10 @@ class LazyInterpreter:
         if height is None:
             log.debug("Image has no Height: %r", stream)
             height = 1
+        if "StructParent" in stream:
+            parent_key = int_value(stream["StructParent"])
+        else:
+            parent_key = None
         return self.create(
             ImageObject,
             stream=stream,
@@ -480,6 +484,7 @@ class LazyInterpreter:
             imagemask=stream.get_any(("IM", "ImageMask")),
             bits=stream.get_any(("BPC", "BitsPerComponent"), 1),
             colorspace=colorspace,
+            _parentkey=parent_key,
         )
 
     def do_q(self) -> None:

--- a/playa/page.py
+++ b/playa/page.py
@@ -28,7 +28,6 @@ from playa.content import (
     ContentObject,
     GlyphObject,
     ImageObject,
-    MarkedContent,
     PathObject,
     TextObject,
     XObjectObject,
@@ -306,45 +305,6 @@ class Page:
             except StopIteration:
                 return
             yield tok
-
-    @property
-    def marked_contents(
-        self,
-    ) -> Iterable[Tuple[Union[MarkedContent, None], Iterator[ContentObject]]]:
-        """Iterator over marked and unmarked content sections.
-
-        This iterates over all objects on the page (including those
-        inside Form XObjects), grouped by their containing marked
-        content section, if any.  Objects outside marked content
-        sections are also returned, with `None` as the first element
-        of the tuple.
-
-        Currently this is just a wrapper around `itertools.groupby`,
-        but in the future it may return a more interesting iterable object.
-
-        Danger: Single-use and stateful iterators.
-            As with `itertools.groupby`, it is not possible to reuse
-            the iterators which are the second element of the tuples
-            returned by this generator.  But worse yet, because these
-            iterators update the graphics state, if you attempt to
-            save them to `list` like flake8 suggests to do, you will
-            possibly get inconsistent results.
-
-        Note: Marked contents are not structure elements.  Because
-            Reasons (Adobe, Spiderman, etc), PDF has unclear and
-            overlapping notions of tags, marked content and logical
-            structure.  This means that marked content sections may or
-            may not be associated to logical structure elements.  If
-            the `mcid` attribute is not `None`, then a corresponding
-            element *might* exist, which you can access through
-            `page.structure`.
-
-        """
-        for mcs, group in itertools.groupby(self.flatten(), operator.attrgetter("mcs")):
-            yield mcs, group
-            # Consume any remaining objects in group
-            for _ in group:  # noqa: B031
-                pass
 
     @property
     def structure(self) -> Sequence[Union["Element", None]]:

--- a/playa/page.py
+++ b/playa/page.py
@@ -348,7 +348,7 @@ class Page:
         sections, the same element may occur multiple times in this
         list.
 
-        Note: This is not the same as `Document.structure`.
+        Note: This is not the same as `playa.Document.structure`.
             PDF documents have logical structure, but PDF pages **do
             not**, and it is dishonest to pretend otherwise (as some
             code I once wrote unfortunately does).  What they do have
@@ -389,7 +389,7 @@ class Page:
     def fonts(self) -> Mapping[str, Font]:
         """Mapping of resource names to fonts for this page.
 
-        Note: Resource names are not font names.
+        Note: This is not the same as `playa.Document.fonts`.
             The resource names (e.g. `F1`, `F42`, `FooBar`) here are
             specific to a page (or Form XObject) resource dictionary
             and have no relation to the font name as commonly

--- a/playa/page.py
+++ b/playa/page.py
@@ -307,6 +307,13 @@ class Page:
             yield tok
 
     @property
+    def parent_key(self) -> Union[int, None]:
+        """Parent tree key for this page, if any."""
+        if "StructParents" in self.attrs:
+            return int_value(self.attrs["StructParents"])
+        return None
+
+    @property
     def structure(self) -> Sequence[Union["Element", None]]:
         """Mapping of marked content IDs to logical structure elements.
 
@@ -336,12 +343,11 @@ class Page:
         self._structmap = []
         if self.doc.structure is None:
             return self._structmap
-        if "StructParents" not in self.attrs:
+        parent_key = self.parent_key
+        if parent_key is None:
             return self._structmap
         try:
-            parents = list_value(
-                self.doc.structure.parent_tree[self.attrs["StructParents"]]
-            )
+            parents = list_value(self.doc.structure.parent_tree[parent_key])
         except IndexError:
             return self._structmap
         # Elements can contain multiple marked content sections, so

--- a/playa/page.py
+++ b/playa/page.py
@@ -504,6 +504,9 @@ class Page:
         # their text, origin, and displacement, will be refactored
         for mcs, texts in itertools.groupby(self.texts, operator.attrgetter("mcs")):
             text: Union[TextObject, None] = None
+            # TODO: Artifact can also be a structure element, but
+            # also, any content outside the structure tree is
+            # considered an artifact
             if mcs is None or mcs.tag == "Artifact":
                 for text in texts:
                     prev_origin = text.origin

--- a/playa/page.py
+++ b/playa/page.py
@@ -31,6 +31,7 @@ from playa.content import (
     PathObject,
     TextObject,
     XObjectObject,
+    _extract_mcid_texts,
 )
 from playa.exceptions import PDFSyntaxError
 from playa.font import Font
@@ -414,6 +415,21 @@ class Page:
             for obj in flatten_one(self, set()):
                 if isinstance(obj, filter_class):
                     yield obj
+
+    @property
+    def mcid_texts(self) -> Mapping[int, List[str]]:
+        """Mapping of marked content IDs to Unicode text strings.
+
+        For use in text extraction from tagged PDFs.
+
+        Danger: Do not rely on this being a `dict`.
+            Currently this is implemented eagerly, but in the future it
+            may return a lazy object.
+        """
+        if hasattr(self, "_textmap"):
+            return self._textmap
+        self._textmap: Mapping[int, List[str]] = _extract_mcid_texts(self)
+        return self._textmap
 
     def extract_text(self) -> str:
         """Do some best-effort text extraction.

--- a/playa/page.py
+++ b/playa/page.py
@@ -307,6 +307,7 @@ class Page:
                 return
             yield tok
 
+    @property
     def marked_contents(
         self,
     ) -> Iterable[Tuple[Union[MarkedContent, None], Iterator[ContentObject]]]:

--- a/playa/page.py
+++ b/playa/page.py
@@ -16,6 +16,7 @@ from typing import (
     Literal,
     Mapping,
     Optional,
+    Sequence,
     Tuple,
     Type,
     TypeVar,
@@ -27,6 +28,7 @@ from playa.content import (
     ContentObject,
     GlyphObject,
     ImageObject,
+    MarkedContent,
     PathObject,
     TextObject,
     XObjectObject,
@@ -38,11 +40,13 @@ from playa.parser import ContentParser, PDFObject, Token
 from playa.pdftypes import (
     MATRIX_IDENTITY,
     ContentStream,
+    ObjRef,
     PSLiteral,
     Point,
     Rect,
     dict_value,
     int_value,
+    list_value,
     literal_name,
     rect_value,
     resolve1,
@@ -53,6 +57,7 @@ from playa.worker import PageRef, _deref_document, _deref_page, _ref_document, _
 
 if TYPE_CHECKING:
     from playa.document import Document
+    from playa.structure import Element
 
 log = logging.getLogger(__name__)
 
@@ -86,6 +91,7 @@ class Page:
     """
 
     _fontmap: Union[Dict[str, Font], None] = None
+    _structmap: Union[List[Union["Element", None]], None] = None
 
     def __init__(
         self,
@@ -231,7 +237,7 @@ class Page:
     @property
     def contents(self) -> Iterator[PDFObject]:
         """Iterator over PDF objects in the content streams."""
-        for pos, obj in ContentParser(self._contents):
+        for _, obj in ContentParser(self._contents):
             yield obj
 
     def __iter__(self) -> Iterator["ContentObject"]:
@@ -302,8 +308,86 @@ class Page:
             yield tok
 
     @property
+    def marked_contents(
+        self,
+    ) -> Iterable[Tuple[MarkedContent, Iterator[ContentObject]]]:
+        """Iterator over marked content sections.
+
+        Currently this is just a wrapper around `itertools.groupby`,
+        but in the future it may return a more interesting iterable object.
+
+        Danger: Single-use and stateful iterators.
+            Because the iterator returned updates the graphics state, it
+            is not possible to reuse it, but worse yet, if you attempt to
+            save it to a `list` like flake8 suggests to do, you will
+            possibly get inconsistent results.
+
+        Note: Marked contents are not structure elements.  Because
+            Reasons (Adobe, Spiderman, etc), PDF has unclear and
+            overlapping notions of tags, marked content and logical
+            structure.  This means that marked content sections may or
+            may not be associated to logical structure elements.  If
+            the `mcid` attribute is not `None`, then a corresponding
+            element *might* exist, which you can access through
+            `page.structure`.
+        """
+        for mcs, group in itertools.groupby(self, operator.attrgetter("mcs")):
+            yield mcs, group
+            # Consume any remaining objects in group
+            for _ in group:  # noqa: B031
+                pass
+
+    @property
+    def structure(self) -> Sequence[Union["Element", None]]:
+        """Mapping of marked content IDs to logical structure elements.
+
+        This is actually a list of logical structure elements
+        corresponding to marked content IDs, or `None` for indices
+        which do not correspond to a marked content ID.  Note that
+        because structure elements may contain multiple marked content
+        sections, the same element may occur multiple times in this
+        list.
+
+        Note: This is not the same as `Document.structure`.
+            PDF documents have logical structure, but PDF pages **do
+            not**, and it is dishonest to pretend otherwise (as some
+            code I once wrote unfortunately does).  What they do have
+            is marked content sections which correspond to content
+            items in the logical structure tree.
+
+        Danger: Do not rely on this being a `list`.
+            Currently this is implemented eagerly, but in the future it
+            may return a lazy object.
+
+        """
+        from playa.structure import Element
+
+        if self._structmap is not None:
+            return self._structmap
+        self._structmap = []
+        if self.doc.structure is None:
+            return self._structmap
+        if "StructParents" not in self.attrs:
+            return self._structmap
+        try:
+            parents = list_value(
+                self.doc.structure.parent_tree[self.attrs["StructParents"]]
+            )
+        except IndexError:
+            return self._structmap
+        # Elements can contain multiple marked content sections, so
+        # don't create redundant Element objects for these
+        elements: Dict[int, Element] = {}
+        for obj in parents:
+            objid = obj.objid if isinstance(obj, ObjRef) else id(obj)
+            if objid not in elements:
+                elements[objid] = Element.from_dict(self.doc, dict_value(obj))
+            self._structmap.append(elements[objid])
+        return self._structmap
+
+    @property
     def fonts(self) -> Mapping[str, Font]:
-        """Get the mapping of resource names to fonts for this page.
+        """Mapping of resource names to fonts for this page.
 
         Note: Resource names are not font names.
             The resource names (e.g. `F1`, `F42`, `FooBar`) here are
@@ -459,13 +543,14 @@ class Page:
             if actual_text is None:
                 reversed = mcs.tag == "ReversedChars"
                 c = []
-                for text in texts:
+                for text in texts:  # noqa: B031
                     c.append(text.chars[::-1] if reversed else text.chars)
                 chars = "".join(c)
             else:
                 assert isinstance(actual_text, bytes)
                 chars = actual_text.decode("UTF-16")
-                for text in texts:
+                # Consume all text objects to ensure correct graphicstate
+                for _ in texts:  # noqa: B031
                     pass
 
             # Remove soft hyphens

--- a/playa/structure.py
+++ b/playa/structure.py
@@ -111,6 +111,24 @@ class ContentItem:
             )
         return self._bbox
 
+    @property
+    def text(self) -> Union[str, None]:
+        """Unicode text contained in this structure element."""
+        page = self.page
+        if page is None:
+            return None
+        itor: Union["Page", "XObjectObject"] = page
+        if self.stream is not None:
+            # FIXME: Potentially quite slow, but we hope this never happens
+            for obj in page.xobjects:
+                if obj.stream.objid == self.stream.objid:
+                    itor = obj
+            # FIXME: if we don't find it... then what? (probably None, but...)
+        texts = itor.mcid_texts.get(self.mcid)
+        if texts is None:
+            return None
+        return "".join(texts)
+
 
 @dataclass
 class ContentObject:

--- a/playa/structure.py
+++ b/playa/structure.py
@@ -17,7 +17,6 @@ from typing import (
     Union,
 )
 
-from playa.content import XObjectObject, GraphicState
 from playa.data_structures import NumberTree
 from playa.parser import LIT, PDFObject, PSLiteral
 from playa.pdftypes import (

--- a/playa/structure.py
+++ b/playa/structure.py
@@ -77,13 +77,16 @@ class ContentItem:
 
     @property
     def bbox(self) -> Rect:
-        """Find the bounding box, if any, of this item.
+        """Find the bounding box, if any, of this item, which is the
+        smallest rectangle enclosing all objects in its marked content
+        section.
 
         Note that this is currently quite inefficient as it involves
-        parsing the entire page.
+        interpreting the entire page.
 
         If the `page` attribute is `None`, then `bbox` will be
         `BBOX_NONE`.
+
         """
         if self._bbox is not None:
             return self._bbox
@@ -350,11 +353,15 @@ class Element(Findable):
         the smallest rectangle enclosing all of the content items
         contained by this element (which may take some time to compute).
 
+        Note that this is currently quite inefficient as it involves
+        interpreting the entire page.
+
         Note: Elements may span multiple pages!
             In the case of an element (such as a `Document` for
             instance) that spans multiple pages, the bounding box
-            cannot exist, and `BBOX_NONE` will be returned.  If then
-            `page` attribute is `None`, then `bbox` will be `BBOX_NONE`.
+            cannot exist, and `BBOX_NONE` will be returned.  If the
+            `page` attribute is `None`, then `bbox` will be
+            `BBOX_NONE`.
 
         """
         page = self.page

--- a/playa/structure.py
+++ b/playa/structure.py
@@ -89,8 +89,11 @@ class ContentItem:
             return self._bbox
         page = self.page
         if page is None:
-            return BBOX_NONE
-        self._bbox = get_bound_rects(obj.bbox for obj in page if obj.mcid == self.mcid)
+            self._bbox = BBOX_NONE
+        else:
+            self._bbox = get_bound_rects(
+                obj.bbox for obj in page if obj.mcid == self.mcid
+            )
         return self._bbox
 
 

--- a/playa/structure.py
+++ b/playa/structure.py
@@ -137,6 +137,7 @@ class ContentObject:
             from playa.page import Annotation
 
             return Annotation.from_dict(self.props, self.page)
+        # Otherwise, we don't know what to do with it!
         return None
 
     @property
@@ -153,6 +154,17 @@ class ContentObject:
     def page(self) -> "Page":
         """Containing page for this content object."""
         return _deref_page(self._pageref)
+
+    @property
+    def bbox(self) -> Rect:
+        """Find the bounding box, if any, of this object.
+
+        If there is no bounding box (very unlikely) this will be
+        `BBOX_NONE`.
+        """
+        if self.obj is None:
+            return BBOX_NONE
+        return self.obj.bbox
 
 
 def _find_all(

--- a/samples/structure_xobjects.pdf
+++ b/samples/structure_xobjects.pdf
@@ -136,7 +136,7 @@ endobj
      /S /P
      /Pg 4 0 R
      /P 10 0 R
-     /K [0]
+     /K [<< /Type /MCR /Pg 4 0 R /Stm 6 0 R /MCID 0 >>]
   >>
 endobj
 
@@ -145,7 +145,7 @@ endobj
      /S /P
      /Pg 4 0 R
      /P 10 0 R
-     /K [1]
+     /K [<< /Type /MCR /Pg 4 0 R /Stm 6 0 R /MCID 1 >>]
   >>
 endobj
 
@@ -154,7 +154,7 @@ endobj
      /S /P
      /Pg 4 0 R
      /P 10 0 R
-     /K [<< /Type /MCR /Pg 4 0 R /Stm 6 0 R /MCID 0 >>]
+     /K [0]
   >>
 endobj
 

--- a/samples/structure_xobjects.pdf
+++ b/samples/structure_xobjects.pdf
@@ -31,24 +31,35 @@ endobj
   /ProcSet [ /PDF /Text /ImageC ]
   /XObject << /X1 6 0 R
               /X2 8 0 R >>
+  /Font << /F1 7 0 R >>
  >>
 >>
 endobj
 5 0 obj
-<< /Length 85 >>
+<< /Length 0 >>
 stream
 q
-1 0 0 1 25 200 cm /X1 Do
+1 0 0 1 25 150 cm /X1 Do
 Q
-/Figure <</MCID 1>> BDC
+q
 212 0 0 121 25 25 cm /X2 Do
+Q
+BT
+250 200 Td
+/F1 24 Tf
+% NOTE: MCID is scoped to page's content stream(s)
+/P <</MCID 0>> BDC
+(Hello again) Tj
 EMC
+ET
+/F1
 endstream
 endobj
 6 0 obj
 << /Subtype /Form
-   /Length 33
+   /Length 0
    /BBox [0 0 500 300]
+   /StructParents 1
    /Resources <<
      /ProcSet [ /PDF /Text ]
      /Font << /F1 7 0 R >>
@@ -56,8 +67,16 @@ endobj
 >>
 stream
 BT
+0 72 Td
 /F1 24 Tf
+% NOTE: MCID is scoped to Form XObject (not page)
+/P <</MCID 0>> BDC
 (Hello world) Tj
+EMC
+0 -36 Td
+/P <</MCID 1>> BDC
+(Goodbye now) Tj
+EMC
 ET
 endstream
 endobj
@@ -72,13 +91,14 @@ endobj
 endobj
 8 0 obj
 <<
-  /Name /X
+  /Name /X2
   /Subtype /Image
   /BitsPerComponent 8
   /ColorSpace /DeviceRGB
   /DecodeParms <</BitsPerComponent 8/Colors 3/Columns 3>>
   /Filter /ASCIIHexDecode
   /Type /XObject
+  /StructParent 2
   /Width 3
   /Height 5
   /Length 105
@@ -93,7 +113,7 @@ endstream
 endobj
 9 0 obj
   << /Type /StructTreeRoot
-     /ParentTree << /Nums [ 0 [4 0 R] ] >>
+     /ParentTree << /Nums [ 0 [13 0 R] 1 [11 0 R 12 0 R] 2 14 0 R ]>>
      /RoleMap << /Title /P >>
      /ClassMap << /C1 << /O /Foo /A1 1 >>
                   /C2 << /O /Foo /A1 3 >>
@@ -107,12 +127,46 @@ endobj
      /S /Document
      /Pg 4 0 R
      /P 9 0 R
-     /K [
-        << /Type /OBJR /Pg 4 0 R /Obj 6 0 R >>
-        1
-     ]
+     /K [ 11 0 R 12 0 R 13 0 R 14 0 R ]
   >>
 endobj
+
+11 0 obj
+  << /Type /StructElem
+     /S /P
+     /Pg 4 0 R
+     /P 10 0 R
+     /K [0]
+  >>
+endobj
+
+12 0 obj
+  << /Type /StructElem
+     /S /P
+     /Pg 4 0 R
+     /P 10 0 R
+     /K [1]
+  >>
+endobj
+
+13 0 obj
+  << /Type /StructElem
+     /S /P
+     /Pg 4 0 R
+     /P 10 0 R
+     /K [<< /Type /MCR /Pg 4 0 R /Stm 6 0 R /MCID 0 >>]
+  >>
+endobj
+
+14 0 obj
+  << /Type /StructElem
+     /S /Figure
+     /Pg 4 0 R
+     /P 10 0 R
+     /K [<< /Type /OBJR /Pg 4 0 R /Obj 8 0 R >>]
+  >>
+endobj
+
 
 trailer 
 <<

--- a/samples/structure_xobjects.pdf
+++ b/samples/structure_xobjects.pdf
@@ -170,7 +170,7 @@ endobj
 
 trailer 
 <<
- /Size 8
+ /Size 14
  /Root 1 0 R
 >>
 %%EOF

--- a/samples/structure_xobjects_2.pdf
+++ b/samples/structure_xobjects_2.pdf
@@ -1,0 +1,135 @@
+%PDF-1.4
+1 0 obj
+<<
+ /Type /Catalog
+ /Outlines 2 0 R
+ /Pages 3 0 R
+ /StructTreeRoot 9 0 R
+>>
+endobj
+2 0 obj
+<<
+ /Type /Outlines
+ /Count 0
+>>
+endobj
+3 0 obj
+<<
+ /Type /Pages
+ /Kids [ 4 0 R ]
+ /Count 1
+>>
+endobj
+4 0 obj
+<<
+ /Type /Page
+ /Parent 3 0 R
+ /MediaBox [ 0 0 500 300 ]
+ /Contents 5 0 R
+ /StructParents 0
+ /Resources <<
+  /ProcSet [ /PDF /Text /ImageC ]
+  /XObject << /X1 6 0 R
+              /X2 8 0 R >>
+ >>
+>>
+endobj
+5 0 obj
+<< /Length 0 >>
+stream
+/Figure <</MCID 0>> BDC
+q
+50 0 0 50 25 150 cm /X1 Do
+Q
+EMC
+q
+212 0 0 121 25 25 cm /X2 Do
+Q
+endstream
+endobj
+6 0 obj
+<<
+  /Name /X1
+  /Subtype /Image
+  /BitsPerComponent 8
+  /ColorSpace /DeviceRGB
+  /DecodeParms <</BitsPerComponent 8/Colors 3/Columns 3>>
+  /Filter /ASCIIHexDecode
+  /Type /XObject
+  /Width 3
+  /Height 5
+  /Length 105
+>>
+stream
+AA2222 22AA22 2222AA
+EEEEEE EEEEEE EEEEEE
+AAAAAA AAAAAA AAAAAA
+EEEEEE EEEEEE EEEEEE
+AAAAAA AAAAAA AAAAAA
+endstream
+endobj
+8 0 obj
+<<
+  /Name /X2
+  /Subtype /Image
+  /BitsPerComponent 8
+  /ColorSpace /DeviceRGB
+  /DecodeParms <</BitsPerComponent 8/Colors 3/Columns 3>>
+  /Filter /ASCIIHexDecode
+  /Type /XObject
+  /StructParent 1
+  /Width 3
+  /Height 5
+  /Length 105
+>>
+stream
+AA2222 22AA22 2222AA
+EEEEEE EEEEEE EEEEEE
+AAAAAA AAAAAA AAAAAA
+EEEEEE EEEEEE EEEEEE
+AAAAAA AAAAAA AAAAAA
+endstream
+endobj
+9 0 obj
+  << /Type /StructTreeRoot
+     /ParentTree << /Nums [ 0 [11 0 R] 1 12 0 R ]>>
+     /RoleMap << /Title /P >>
+     /K [10 0 R]
+  >>
+endobj
+
+10 0 obj
+  << /Type /StructElem
+     /S /Document
+     /Pg 4 0 R
+     /P 9 0 R
+     /K [ 11 0 R 12 0 R ]
+  >>
+endobj
+
+11 0 obj
+  << /Type /StructElem
+     /S /Figure
+     /Pg 4 0 R
+     /P 10 0 R
+     /K [0]
+  >>
+endobj
+
+
+12 0 obj
+  << /Type /StructElem
+     /S /Figure
+     /Pg 4 0 R
+     /P 10 0 R
+     /K [<< /Type /OBJR /Pg 4 0 R /Obj 8 0 R >>]
+  >>
+endobj
+
+
+trailer 
+<<
+ /Size 12
+ /Root 1 0 R
+>>
+%%EOF

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -115,5 +115,15 @@ def test_structure_bbox() -> None:
             assert item.bbox is not BBOX_NONE
 
 
+def test_content_structure() -> None:
+    """Verify that we can access structure elements from content objects."""
+    with playa.open(TESTDIR / "pdf_structure.pdf") as pdf:
+        for obj in pdf.pages[0]:
+            if obj.object_type == "path":
+                assert obj.parent is None
+            else:
+                assert obj.parent.role in ("P", "H1", "H2", "H3")
+
+
 if __name__ == "__main__":
     test_specific_structure()

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -128,14 +128,13 @@ def test_xobject_mcids() -> None:
         img = next(pdf.pages[0].images)
         assert img.parent is not None
         (cobj,) = img.parent
-        assert isinstance(item, ContentObject)
+        assert isinstance(cobj, ContentObject)
         assert cobj.bbox == img.bbox
         assert cobj.bbox == fig.bbox
 
 
 def test_mcid_texts() -> None:
-    """Verify that we can access marked content sections inside Form
-    XObjects (ark) using marked-content reference dictionaries."""
+    """Verify that we can get text from marked content sections."""
     with playa.open(TESTDIR / "structure_xobjects.pdf") as pdf:
         page = pdf.pages[0]
         assert page.mcid_texts == {0: ["Hello again"]}

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -106,6 +106,16 @@ def test_xobject_mcids() -> None:
         assert item.bbox == pytest.approx((25, 60.768, 143.68, 82.968))
 
 
+def test_mcid_texts() -> None:
+    """Verify that we can access marked content sections inside Form
+    XObjects (ark) using marked-content reference dictionaries."""
+    with playa.open(TESTDIR / "structure_xobjects.pdf") as pdf:
+        page = pdf.pages[0]
+        assert page.mcid_texts == {0: ["Hello again"]}
+        xobj = next(page.xobjects)
+        assert xobj.mcid_texts == {0: ["Hello world"], 1: ["Goodbye now"]}
+
+
 def test_structure_bbox() -> None:
     """Verify that we can get the bounding box of structure elements."""
     with playa.open(TESTDIR / "pdf_structure.pdf") as pdf:

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -5,6 +5,7 @@ import pytest
 import playa
 from playa.exceptions import PDFEncryptionError
 from playa.page import Annotation, XObjectObject, TextObject
+from playa.pdftypes import BBOX_NONE
 from playa.structure import Element, Tree, ContentItem, ContentObject
 
 from .data import ALLPDFS, CONTRIB, PASSWORDS, TESTDIR, XFAILS
@@ -98,15 +99,19 @@ def test_structure_bbox() -> None:
         assert pdf.structure is not None
         table = pdf.structure.find("Table")
         assert table is not None
-        print(table.bbox)
+        assert table.bbox is not BBOX_NONE
         li = pdf.structure.find("LI")
         assert li is not None
-        print(li.bbox)
+        assert li.bbox is not BBOX_NONE
+        for item in li.contents:
+            assert item.bbox is not BBOX_NONE
     with playa.open(TESTDIR / "image_structure.pdf") as pdf:
         assert pdf.structure is not None
         figure = pdf.structure.find("Figure")
         assert figure is not None
-        print(figure.bbox)
+        assert figure.bbox is not BBOX_NONE
+        for item in figure.contents:
+            assert item.bbox is not BBOX_NONE
 
 
 if __name__ == "__main__":

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -6,7 +6,7 @@ import playa
 from playa.exceptions import PDFEncryptionError
 from playa.page import Annotation, ImageObject
 from playa.pdftypes import BBOX_NONE
-from playa.structure import Element, Tree, ContentObject
+from playa.structure import Element, Tree, ContentItem, ContentObject
 
 from .data import ALLPDFS, CONTRIB, PASSWORDS, TESTDIR, XFAILS
 
@@ -105,22 +105,32 @@ def test_xobject_mcids() -> None:
         assert isinstance(p3, Element)
         assert isinstance(fig, Element)
         (item,) = p1
+        assert isinstance(item, ContentItem)
         assert item.text == "Hello world"
+        assert item.bbox == p1.bbox
         (item,) = p2
+        assert isinstance(item, ContentItem)
         assert item.text == "Goodbye now"
+        assert item.bbox == p2.bbox
         (item,) = p3
+        assert isinstance(item, ContentItem)
         assert item.text == "Hello again"
+        assert item.bbox == p3.bbox
         xobj = next(pdf.pages[0].xobjects)
         for obj in xobj:
             assert obj.parent is not None
             (item,) = obj.parent.contents
+            assert isinstance(item, ContentItem)
             assert item.mcid == obj.mcid
             assert item.bbox == obj.bbox
+            assert item.stream is not None
             assert item.stream.objid == xobj.stream.objid
         img = next(pdf.pages[0].images)
         assert img.parent is not None
         (cobj,) = img.parent
+        assert isinstance(item, ContentObject)
         assert cobj.bbox == img.bbox
+        assert cobj.bbox == fig.bbox
 
 
 def test_mcid_texts() -> None:

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -133,6 +133,21 @@ def test_xobject_mcids() -> None:
         assert cobj.bbox == fig.bbox
 
 
+def test_image_in_mcs() -> None:
+    """Verify that we can access images both through marked content
+    sections and OBJRs."""
+    with playa.open(TESTDIR / "structure_xobjects_2.pdf") as pdf:
+        img1, img2 = pdf.pages[0].images
+        assert img1.parent is not None
+        (item,) = img1.parent
+        assert isinstance(item, ContentItem)
+        assert item.bbox == img1.bbox
+        assert img2.parent is not None
+        (cobj,) = img2.parent
+        assert isinstance(cobj, ContentObject)
+        assert cobj.bbox == img2.bbox
+
+
 def test_mcid_texts() -> None:
     """Verify that we can get text from marked content sections."""
     with playa.open(TESTDIR / "structure_xobjects.pdf") as pdf:

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -99,11 +99,28 @@ def test_xobject_mcids() -> None:
         assert pdf.structure is not None
         top = pdf.structure.find("Document")
         assert top is not None
-        _, _, p, _ = top
-        assert isinstance(p, Element)
-        (item,) = p
-        # Make sure we get the right one!
-        assert item.bbox == pytest.approx((25, 60.768, 143.68, 82.968))
+        p1, p2, p3, fig = top
+        assert isinstance(p1, Element)
+        assert isinstance(p2, Element)
+        assert isinstance(p3, Element)
+        assert isinstance(fig, Element)
+        (item,) = p1
+        assert item.text == "Hello world"
+        (item,) = p2
+        assert item.text == "Goodbye now"
+        (item,) = p3
+        assert item.text == "Hello again"
+        xobj = next(pdf.pages[0].xobjects)
+        for obj in xobj:
+            assert obj.parent is not None
+            (item,) = obj.parent.contents
+            assert item.mcid == obj.mcid
+            assert item.bbox == obj.bbox
+            assert item.stream.objid == xobj.stream.objid
+        img = next(pdf.pages[0].images)
+        assert img.parent is not None
+        (cobj,) = img.parent
+        assert cobj.bbox == img.bbox
 
 
 def test_mcid_texts() -> None:

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -72,6 +72,7 @@ def test_annotations() -> None:
             for kid in link:
                 if isinstance(kid, ContentObject):
                     assert isinstance(kid.obj, Annotation)
+                    assert kid.bbox is not BBOX_NONE
 
 
 def test_content_xobjects() -> None:

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -122,6 +122,7 @@ def test_content_structure() -> None:
             if obj.object_type == "path":
                 assert obj.parent is None
             else:
+                assert obj.parent is not None
                 assert obj.parent.role in ("P", "H1", "H2", "H3")
 
 

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -2,13 +2,34 @@
 Test rudimentary text extraction functionality.
 """
 
+import pytest
+
 import playa
 
-from .data import TESTDIR
+from .data import TESTDIR, CONTRIB
+
+
+def test_exotic_ctm() -> None:
+    """Make sure text extraction works even when the CTM is weird."""
+    with playa.open(TESTDIR / "zen_of_python_corrupted.pdf") as pdf:
+        text = pdf.pages[0].extract_text()
+        assert text.startswith("""\
+Beautiful is better than ugly.
+Explicit is better than implicit.
+Simple is better than complex.""")
 
 
 def test_spaces_between_objects() -> None:
     """Make sure we can insert spaces between TextObjects on the same "line"."""
     with playa.open(TESTDIR / "graphics_state_in_text_object.pdf") as pdf:
         text = pdf.pages[0].extract_text()
-        assert text == "foo  A B CDBAR\nFOOHello World"
+        assert text == "foo A B CDBAR\nFOOHello World"
+
+
+@pytest.mark.skipif(not CONTRIB.exists(), reason="contrib samples not present")
+def test_tagged_line_breaks() -> None:
+    """Make sure we only insert line breaks between marked content
+    where there are actually line breaks."""
+    with playa.open(CONTRIB / "2023-06-20-PV.pdf") as pdf:
+        text = pdf.pages[0].extract_text()
+        assert "4. Demande" in text


### PR DESCRIPTION
These all go together becaues the marked content improvements are used in text extraction

- Add ability to access structure elements from marked content IDs
- Add ability to access structure element parents from content objects
- Use device space instead of unscaled text space to determine word and line breaks
- Correct the space and line break insertion between marked content sections when extracting text from tagged PDF

Remaining TODOs:

- [x] correct the text extraction in `playa --structure` to respect the actual scope of MCIDS (page or form xobject)
- [x] correct `ContentObject.parent` to get `StructParents` from an enclosing Form XObject if one exists
- [x] test that `ImageObject.parent` and `XObjectObject.parent` use `StructParent` if it exists, and `StructParents` if not
- [x] change `playa.cli.get_mcid_text` to a `text` property on `ContentItem` (do we need it for `ContentObject`?)
- [x] benchmark and optimize `text` <del>and `bbox`</del> properties on structure objects (only half done)