### PR TITLE
fix: correct bogus font descriptors with zero metrics

### DIFF
--- a/playa/font.py
+++ b/playa/font.py
@@ -111,6 +111,12 @@ class Font:
             self.descent = -self.descent
         # NOTE: A Type3 font *can* have positive descent because the
         # FontMatrix might be flipped, this is handled in the subclass
+        # (but also, we ignore ascent and descent on Type3 fonts)
+
+        # For some unknown reason sometimes Ascent and Descent are
+        # both zero, in which case set them from the bbox.
+        if self.ascent == 0 and self.descent == 0:
+            _, self.descent, _, self.ascent = self.bbox
 
     def __repr__(self) -> str:
         return "<Font>"
@@ -400,8 +406,10 @@ class Type3Font(SimpleFont):
         if "FontBBox" in spec:  # it is also required though
             self.bbox = rect_value(spec["FontBBox"])
             # otherwise it was set in SimpleFont.__init__
+
         # Set ascent/descent from the bbox (they *could* be in the
-        # descriptor but this is very unlikely)
+        # descriptor but this is very unlikely, and then, they might
+        # also both be zero, which is bad)
         _, self.descent, _, self.ascent = self.bbox
 
     def get_implicit_encoding(

--- a/playa/interp.py
+++ b/playa/interp.py
@@ -107,6 +107,7 @@ class TextState:
 
 def _make_fontmap(mapping: PDFObject, doc: "Document") -> Dict[str, Font]:
     fontmap: Dict[str, Font] = {}
+    mapping = resolve1(mapping)
     if not isinstance(mapping, dict):
         log.warning("Font mapping not a dict: %r", mapping)
         return fontmap

--- a/tests/test_fonts.py
+++ b/tests/test_fonts.py
@@ -200,3 +200,11 @@ def test_type3_charprocs() -> None:
             (0.0068359382, 0.0, 0.0, 0.0068359382, 25.0, 25.0)
         )
         print(list(p.segments))
+
+
+def test_bogus_metrics() -> None:
+    """Verify that we fix bogus font descriptors with ascent = descent = 0."""
+    with playa.open(TESTDIR / "pdf_structure.pdf") as pdf:
+        for t in pdf.pages[0].texts:
+            x0, y0, x1, y1 = t.bbox
+            assert y1 > y0


### PR DESCRIPTION
Some creators of subset fonts (*cough* LibreOffice) have decided that zero is a helpful value for Ascent and Descent on fonts, for some reason.  Before when we had `get_ascent()` and `get_descent()` methods these were fixed up to use the bbox, and this got removed, oops, causing a regression.

At least now we have a test.

Also the previous code was wrong because it didn't allow for the case where the descent really was zero (ok, yeah, it's supposed to be a *negative* number, not a *non-positive* one, but still).  To be safe we just look for this particular bogus pattern of no-height fonts.

Also this fixes a small error in the `fonts` property on pages and documents which didn't bother to dereference font resource dictionaries, oops.