### PR TITLE
refactor: image extraction

### DIFF
--- a/playa/image.py
+++ b/playa/image.py
@@ -1,0 +1,191 @@
+import logging
+from pathlib import Path
+from typing import BinaryIO, Union
+
+from playa import asobj
+from playa.color import ColorSpace
+from playa.pdftypes import (
+    LITERALS_DCT_DECODE,
+    LITERALS_JPX_DECODE,
+    LITERALS_JBIG2_DECODE,
+    ContentStream,
+    resolve1,
+    int_value,
+    stream_value,
+)
+
+LOG = logging.getLogger(__name__)
+
+JBIG2_HEADER = b"\x97JB2\r\n\x1a\n"
+
+
+def get_one_image(stream: ContentStream, path: Path) -> Path:
+    fp = stream.get_filters()
+    if fp:
+        filters, params = zip(*fp)
+        for f in filters:
+            if f in LITERALS_DCT_DECODE:
+                path = path.with_suffix(".jpg")
+                break
+            if f in LITERALS_JPX_DECODE:
+                path = path.with_suffix(".jp2")
+                break
+            if f in LITERALS_JBIG2_DECODE:
+                path = path.with_suffix(".jb2")
+                break
+    if path.suffix in (".jpg", ".jp2"):
+        # DCT streams are generally readable as JPEG files, and this
+        # is also generally true for JPEG2000 streams
+        with open(path, "wb") as outfh:
+            outfh.write(stream.buffer)
+    elif path.suffix == ".jb2":
+        # This is not however true for JBIG2, which requires a
+        # particular header
+        with open(path, "wb") as outfh:
+            write_jbig2(outfh, stream)
+    else:
+        # Otherwise, try to write a PNM file
+        bits = stream.bits
+        colorspace: Union[ColorSpace, None] = stream.colorspace
+        ncomponents = 1
+        if colorspace is not None:
+            ncomponents = colorspace.ncomponents
+            if colorspace.name == "Indexed":
+                from playa.color import get_colorspace
+
+                assert isinstance(colorspace.spec, list)
+                _, underlying, _, _ = colorspace.spec
+                colorspace = get_colorspace(resolve1(underlying))
+                if colorspace is not None:
+                    ncomponents = colorspace.ncomponents
+        if bits == 1:
+            path = path.with_suffix(".pbm")
+        elif colorspace is None or colorspace.name not in ("DeviceGray", "DeviceRGB"):
+            path = path.with_suffix(".dat")
+            LOG.warning(
+                "Unsupported colorspace %s, writing data to %s", asobj(colorspace), path
+            )
+        elif ncomponents == 1:
+            path = path.with_suffix(".pgm")
+        elif ncomponents == 3:
+            path = path.with_suffix(".ppm")
+        elif ncomponents == 3:
+            path = path.with_suffix(".ppm")
+        else:
+            path = path.with_suffix(".dat")
+            LOG.warning(
+                "Unsupported colorspace %s, writing data to %s", asobj(colorspace), path
+            )
+
+        if path.suffix != ".dat":
+            try:
+                with open(path, "wb") as outfh:
+                    write_pnm(outfh, stream)
+            except ValueError:
+                datpath = path.with_suffix(".dat")
+                LOG.exception(
+                    "Failed to write PNM to %s, writing data to %s", path, datpath
+                )
+                path = datpath
+
+        if path.suffix == ".dat":
+            with open(path, "wb") as outfh:
+                outfh.write(stream.buffer)
+    return path
+
+
+def write_pnm(outfh: BinaryIO, stream: ContentStream) -> None:
+    """Write stream data to a PBM/PGM/PPM file.
+
+    Raises:
+        ValueError: if stream data cannot be written to a PNM, because of an
+                    unsupported colour space, or an unsupported filter (JBIG2,
+                    DCT or JPEG2000)
+
+    """
+    for f in stream.filters:
+        if f in LITERALS_DCT_DECODE:
+            raise ValueError("Stream is JPEG data, save its buffer directly")
+        if f in LITERALS_JPX_DECODE:
+            raise ValueError("Stream is JPEG2000 data, save its buffer directly")
+        if f in LITERALS_JBIG2_DECODE:
+            raise ValueError("Stream is JBIG2 data, save it with write_jbig2")
+    bits = stream.bits
+    colorspace = stream.colorspace
+    ncomponents = colorspace.ncomponents
+    data = stream.buffer
+    is_bilevel = bits == 1 and ncomponents == 1 and colorspace.name != "Indexed"
+    if not is_bilevel:
+        from playa.utils import unpack_image_data
+
+        data = unpack_image_data(data, bits, stream.width, stream.height, ncomponents)
+    ftype: Union[bytes, None] = None
+    if is_bilevel:
+        ftype = b"P4"
+    elif colorspace.name == "DeviceGray":
+        ftype = b"P5"
+    elif colorspace.name == "DeviceRGB" or colorspace.ncomponents == 3:
+        ftype = b"P6"
+    elif colorspace.name == "Indexed":
+        from playa.color import get_colorspace
+
+        assert isinstance(colorspace.spec, list)
+        _, underlying, hival, lookup = colorspace.spec
+        underlying = get_colorspace(resolve1(underlying))
+        if underlying is None:
+            raise ValueError(
+                "Unknown underlying colorspace in Indexed image: %r" % (underlying,)
+            )
+        if underlying.name == "DeviceGray":
+            ftype = b"P5"
+        elif underlying.name == "DeviceRGB" or underlying.ncomponents == 3:
+            ftype = b"P6"
+        hival = int_value(hival)
+        if not isinstance(lookup, bytes):
+            lookup = stream_value(lookup).buffer
+        channels = len(lookup) // (hival + 1)
+        data = bytes(b for i in data for b in lookup[channels * i : channels * (i + 1)])
+        bits = 8
+    if ftype is None:
+        raise ValueError("Unsupported colorspace: %r" % (stream.colorspace,))
+    max_value = (1 << bits) - 1
+    outfh.write(b"%s %d %d\n" % (ftype, stream.width, stream.height))
+    if is_bilevel:
+        # Have to invert the bits! OMG! (FIXME: is there a more
+        # efficient way to do this?)
+        outfh.write(bytes(x ^ 0xFF for x in data))
+    else:
+        outfh.write(b"%d\n" % max_value)
+        outfh.write(data)
+
+
+def write_jbig2(outfh: BinaryIO, stream: ContentStream) -> None:
+    """Write stream data to a JBIG2 file.
+
+    Raises:
+        ValueError: if stream data is not JBIG2.
+    """
+    if not any(f in LITERALS_JBIG2_DECODE for f in stream.filters):
+        raise ValueError("Stream is not JBIG2")
+    globals_stream = None
+    decode_parms = resolve1(stream.get("DecodeParms"))
+    if isinstance(decode_parms, dict):
+        globals_stream = resolve1(decode_parms.get("JBIG2Globals"))
+    outfh.write(JBIG2_HEADER)
+    # flags
+    outfh.write(b"\x01")
+    # number of pages
+    outfh.write(b"\x00\x00\x00\x01")
+    # write global segments
+    if isinstance(globals_stream, ContentStream):
+        outfh.write(globals_stream.buffer)
+    # write the rest of the data
+    outfh.write(stream.buffer)
+    # and an eof segment
+    outfh.write(
+        b"\x00\x00\x00\x00"  # number (bogus!)
+        b"\x33"  # flags: SEG_TYPE_END_OF_FILE
+        b"\x00"  # retention_flags: empty
+        b"\x00"  # page_assoc: 0
+        b"\x00\x00\x00\x00"  # data_length: 0
+    )

--- a/tests/test_lazy_api.py
+++ b/tests/test_lazy_api.py
@@ -9,7 +9,7 @@ import pytest
 from playa.color import PREDEFINED_COLORSPACE, Color
 from playa.exceptions import PDFEncryptionError
 from playa.utils import get_bound
-from playa.image import write_jbig2, write_pnm
+from playa.image import get_one_image
 
 from .data import ALLPDFS, CONTRIB, PASSWORDS, TESTDIR, XFAILS
 
@@ -254,26 +254,15 @@ def test_glyph_properties(name: str) -> None:
 
 @pytest.mark.skipif(not CONTRIB.exists(), reason="contrib samples not present")
 def test_jbig2(tmp_path) -> None:
-    """Verify that we can extract JBIG2 images, and that we don't try
-    to save JBIG2 to PNM and vice versa."""
+    """Verify that we can extract JBIG2 images."""
     with playa.open(CONTRIB / "pdf-with-jbig2.pdf") as pdf:
         img = next(pdf.pages[0].images)
-        hyppath = tmp_path / "XIPLAYER0.jb2"
-        with open(hyppath, "wb") as outfh:
-            write_jbig2(outfh, img.stream)
+        hyppath = tmp_path / "XIPLAYER0"
+        hyppath = get_one_image(img.stream, hyppath)
+        assert hyppath.suffix == ".jb2"
         refdata = (CONTRIB / "XIPLAYER0.jb2").read_bytes()
         hypdata = hyppath.read_bytes()
         assert refdata == hypdata
-        outpath = tmp_path / "NOWAYNOHOW.pbm"
-        with pytest.raises(ValueError):
-            with open(outpath, "wb") as outfh:
-                write_pnm(outfh, img.stream)
-    with playa.open(TESTDIR / "structure_xobjects_2.pdf") as pdf:
-        img = next(pdf.pages[0].images)
-        outpath = tmp_path / "NOWAYNOHOW.jb2"
-        with pytest.raises(ValueError):
-            with open(outpath, "wb") as outfh:
-                write_jbig2(outfh, img.stream)
 
 
 @pytest.mark.skipif(not CONTRIB.exists(), reason="contrib samples not present")
@@ -282,9 +271,9 @@ def test_indexed_images(tmp_path) -> None:
     correctly."""
     with playa.open(CONTRIB / "issue-1062-filters.pdf") as pdf:
         (img,) = pdf.pages[0].images
-        outpath = tmp_path / "page1.ppm"
-        with open(outpath, "wb") as outfh:
-            write_pnm(outfh, img.stream)
+        outpath = tmp_path / "page1"
+        outpath = get_one_image(img.stream, outpath)
+        assert outpath.suffix == ".ppm"
         refpath = CONTRIB / "page1-0-00005.ppm"
         hyp = outpath.read_bytes()
         ref = refpath.read_bytes()

--- a/tests/test_lazy_api.py
+++ b/tests/test_lazy_api.py
@@ -9,6 +9,7 @@ import pytest
 from playa.color import PREDEFINED_COLORSPACE, Color
 from playa.exceptions import PDFEncryptionError
 from playa.utils import get_bound
+from playa.image import write_jbig2, write_pnm
 
 from .data import ALLPDFS, CONTRIB, PASSWORDS, TESTDIR, XFAILS
 
@@ -259,20 +260,20 @@ def test_jbig2(tmp_path) -> None:
         img = next(pdf.pages[0].images)
         hyppath = tmp_path / "XIPLAYER0.jb2"
         with open(hyppath, "wb") as outfh:
-            img.stream.write_jbig2(outfh)
+            write_jbig2(outfh, img.stream)
         refdata = (CONTRIB / "XIPLAYER0.jb2").read_bytes()
         hypdata = hyppath.read_bytes()
         assert refdata == hypdata
         outpath = tmp_path / "NOWAYNOHOW.pbm"
         with pytest.raises(ValueError):
             with open(outpath, "wb") as outfh:
-                img.stream.write_pnm(outfh)
+                write_pnm(outfh, img.stream)
     with playa.open(TESTDIR / "structure_xobjects_2.pdf") as pdf:
         img = next(pdf.pages[0].images)
         outpath = tmp_path / "NOWAYNOHOW.jb2"
         with pytest.raises(ValueError):
             with open(outpath, "wb") as outfh:
-                img.stream.write_jbig2(outfh)
+                write_jbig2(outfh, img.stream)
 
 
 @pytest.mark.skipif(not CONTRIB.exists(), reason="contrib samples not present")
@@ -283,7 +284,7 @@ def test_indexed_images(tmp_path) -> None:
         (img,) = pdf.pages[0].images
         outpath = tmp_path / "page1.ppm"
         with open(outpath, "wb") as outfh:
-            img.stream.write_pnm(outfh)
+            write_pnm(outfh, img.stream)
         refpath = CONTRIB / "page1-0-00005.ppm"
         hyp = outpath.read_bytes()
         ref = refpath.read_bytes()


### PR DESCRIPTION
mostly just prep work for future refactor, end goal is remove duplicate logic for determining file extension
- all image extraction related code in one file
- `write_jbig2` and `write_pnm` considered internal
