### PR TITLE
feat: cid2gid for CIDFont

### DIFF
--- a/playa/utils.py
+++ b/playa/utils.py
@@ -8,6 +8,7 @@ from typing import (
     Iterable,
     Iterator,
     List,
+    Mapping,
     Tuple,
     TypeVar,
     Union,
@@ -687,3 +688,17 @@ def format_int_alpha(value: int) -> str:
 
     result.reverse()
     return "".join(result)
+
+
+class IdentityMapping(Mapping[_T, _T]):
+    def __getitem__(self, key: _T) -> _T:
+        return key
+
+    def __iter__(self) -> Iterator[_T]:
+        yield from ()
+
+    def __len__(self) -> int:
+        return 0
+
+
+IDENTITY_MAPPING: IdentityMapping = IdentityMapping()


### PR DESCRIPTION
probably fringe but i want this...

manually tested by gathering all gids and corresponding text in a pdf and running through [msdf-atlas-gen](https://github.com/Chlumsky/msdf-atlas-gen)
- Type 2, embedded, stream CIDToGIDMap: Dar_smlouva.pdf from https://github.com/mozilla/pdf.js/issues/10519
- Type 2, embedded, /Identity CIDToGIDMap: samples/vertical_writing.pdf
- Type 0, embedded, no CIDFont ops in Top DICT: samples/utf16_tounicode.pdf
- Type 0, embedded, CIDFont ops in Top DICT: example needed
- Type 0, external: example needed