### PR TITLE
fix: always decode text (fixes: #153)

### DIFF
--- a/playa/utils.py
+++ b/playa/utils.py
@@ -626,7 +626,10 @@ def decode_text(s: Union[str, bytes]) -> str:
     if isinstance(s, bytes) and (
         s.startswith(b"\xfe\xff") or s.startswith(b"\xff\xfe")
     ):
-        return s.decode("UTF-16")
+        try:
+            return s.decode("UTF-16")
+        except UnicodeDecodeError:
+            s = s[2:]
     try:
         # FIXME: This seems bad. If it's already a `str` then what are
         # those PDFDocEncoding characters doing in it?!?

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import itertools
 from typing import cast
-from playa.utils import transform_bbox, get_bound, apply_matrix_pt, Matrix
+from playa.utils import decode_text, transform_bbox, get_bound, apply_matrix_pt, Matrix
 
 
 def test_rotated_bboxes() -> None:
@@ -13,3 +13,14 @@ def test_rotated_bboxes() -> None:
         ctm = cast(Matrix, (*matrix, 0, 0))
         bound = get_bound((apply_matrix_pt(ctm, p) for p in points))
         assert transform_bbox(ctm, bbox) == bound
+
+
+def test_decode_text() -> None:
+    """Make sure we can always decode text, even if it is nonsense."""
+    assert (
+        decode_text(
+            b"\xfe\xffMicrosoft\xae Word 2010; modified using iText 2.1.7 by 1T3XT"
+        )
+        == "Microsoft\xae Word 2010; modified using iText 2.1.7 by 1T3XT"
+    )
+    assert decode_text(b"\xff\xfeW\x00T\x00F\x00-\x001\x006\x00") == "WTF-16"


### PR DESCRIPTION
We should never crash when trying to decode a "text string" even if the encoding is obviously nonsense!

fixes: #153 