### PR TITLE
Greatly accelerate and improve logical structure tasks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,3 +7,5 @@ extend-ignore =
     S101,
     # No, flake8, we meant to call that function do_Tf
     N802,
+    # No, flake8, my docstrings are NOT ReStructuredText
+    RST203,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Make `PageList` work more or less like a `Sequence`
 - Support iteration over `playa.structure.ContentItem`
 - Maximize test coverage
-- TODO: Optimize marked content section access
+- Optimize marked content section access
 - TODO: Add method to complete parent tree for page
 - TODO: Fail fast for incorrect stream lengths
 - TODO: Parse indirect objects with regex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Support iteration over `playa.structure.ContentItem`
 - Maximize test coverage
 - Optimize marked content section access
-- TODO: Add method to complete parent tree for page
+- Add method to complete parent tree for page
 - TODO: Fail fast for incorrect stream lengths
 - TODO: Parse indirect objects with regex
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ would be specifically one of these things and nothing else:
 2. Obtaining the absolute position and attributes of every character,
    line, path, and image in every page of a PDF.
    
+Note that **P**LAYA Ain't a **LAY**out **A**nalyzer, because layout
+analysis as done by
+[pdfminer.six](https://github.com/pdfminer/pdfminer.six)) is Heuristic
+and Not Lazy.  But never fear!  You can now use
+[PAVÉS](https://github.com/dhdaines/paves?tab=readme-ov-file#working-in-the-pdf-mine)
+which implements exactly the `LayoutAnalyzer` API from pdfminer.six
+but without the `NumerousLines.of(FrustratingBoilerplate())` that it
+takes get the layout out of a PDF.  (it does other things, too)
+
 The purpose of PLAYA is to provide an efficent, parallel and
 parallelizable, pure-Python and Pythonic (for its author's definition
 of the term), lazy interface to the internals of PDF files.
@@ -194,6 +203,19 @@ The set of possible entries in annotation dictionaries (PDF 1.7 sect
 12.5.2) is vast and confusing and inconsistently implemented, but you
 can always access them by their names (as defined in the PDF standard)
 via `annot.props`.
+
+If the document has logical structure, then the pages will also have a
+slightly different form of logical structure.  You can use the same
+`find` and `find_all` methods to get all of the enclosing structure
+elements of a given type (actually a role) for a page.  So for
+instance if you wanted to get the text contents for all the cells in
+all the tables on a page, assuming the creator of said page was kind
+enough to check the "PDF/UA" box, you can do:
+
+```python
+for table in page.structure.find_all("Table"):
+    print(f"Table at {table.bbox}: {[x.text for x in table.contents]}")
+```
 
 ## Accessing content
 

--- a/benchmarks/marked_content.py
+++ b/benchmarks/marked_content.py
@@ -1,0 +1,46 @@
+"""
+Benchmark marked content section iteration and extraction.
+"""
+
+import logging
+import time
+from pathlib import Path
+
+import playa
+
+SAMPLES = Path(__file__).parent.parent / "samples"
+CONTRIB = Path(__file__).parent.parent / "samples" / "contrib"
+
+LOG = logging.getLogger("benchmark-text")
+# Use a standard benchmark set to make version comparisons possible
+PDFS = [
+    "2023-04-06-ODJ et Résolutions-séance xtra 6 avril 2023.pdf",
+    "2023-06-20-PV.pdf",
+    "PSC_Station.pdf",
+    "Rgl-1314-2021-DM-Derogations-mineures.pdf",
+]
+
+
+def benchmark_cli(path: Path) -> None:
+    with playa.open(path) as doc:
+        for page in doc.pages:
+            for _mcid, element in enumerate(page.structure):
+                if element is None:
+                    continue
+                _ = element.bbox
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.ERROR)
+    niter = 5
+    cli_time = 0.0
+    for iter in range(niter + 1):
+        for name in PDFS:
+            path = SAMPLES / name
+            if not path.exists():
+                path = CONTRIB / name
+            start = time.time()
+            benchmark_cli(path)
+            if iter != 0:
+                cli_time += time.time() - start
+    print("MCS access took %d ms / iter" % (cli_time / niter * 1000,))

--- a/playa/cli.py
+++ b/playa/cli.py
@@ -413,7 +413,9 @@ def _extract_element(el: Element, indent: int, outfh: TextIO) -> bool:
     ws = " " * indent
     ss = "  "
 
-    text = json.dumps(asobj_structelement(el, recurse=False), indent=2, ensure_ascii=False)
+    text = json.dumps(
+        asobj_structelement(el, recurse=False), indent=2, ensure_ascii=False
+    )
     brace = text.rindex("}")
     print(textwrap.indent(text[:brace].strip(), ws), end="", file=outfh)
     print(f',\n{ws}{ss}"children": [', file=outfh)

--- a/playa/cli.py
+++ b/playa/cli.py
@@ -82,6 +82,7 @@ import itertools
 import json
 import logging
 import re
+import textwrap
 from collections import deque
 from pathlib import Path
 from typing import Any, Deque, Iterable, Iterator, List, TextIO, Tuple, Union
@@ -97,7 +98,6 @@ from playa.pdftypes import (
     ContentStream,
     ObjRef,
     resolve1,
-    str_value,
     PDFObject,
 )
 from playa.structure import ContentItem
@@ -412,37 +412,10 @@ def _extract_element(el: Element, indent: int, outfh: TextIO) -> bool:
     """Extract a single structure element."""
     ws = " " * indent
     ss = "  "
-    s = []
 
-    def format_attr(k: Any, v: Any) -> None:
-        k = json.dumps(k, ensure_ascii=False)
-        v = json.dumps(v, ensure_ascii=False)
-        s.append(f"{ws}{ss}{k}: {v}")
-
-    try:
-        format_attr("type", el.type)
-        format_attr("role", el.role)
-    except KeyError:
-        LOG.warning("Structure element with no type ignored: %r", el)
-        return False
-    except TypeError:
-        LOG.warning("Structure element with invalid type ignored: %r", el)
-        return False
-    page = el.page
-    if page is not None:
-        format_attr("page_idx", page.page_idx)
-    if "T" in el.props:
-        format_attr("title", decode_text(str_value(el.props["T"])))
-    if "Lang" in el.props:
-        format_attr("language", decode_text(str_value(el.props["Lang"])))
-    if "Alt" in el.props:
-        format_attr("alternate_description", decode_text(str_value(el.props["Alt"])))
-    if "E" in el.props:
-        format_attr("abbreviation_expansion", decode_text(str_value(el.props["E"])))
-    if "ActualText" in el.props:
-        format_attr("actual_text", decode_text(str_value(el.props["ActualText"])))
-    print(f"{ws}{{", file=outfh)
-    print(",\n".join(s), end="", file=outfh)
+    text = json.dumps(asobj(el, recurse=False), indent=2, ensure_ascii=False)
+    brace = text.rindex("}")
+    print(textwrap.indent(text[:brace].strip(), ws), end="", file=outfh)
     print(f',\n{ws}{ss}"children": [', file=outfh)
     comma = False
     for kid in el:
@@ -451,6 +424,7 @@ def _extract_element(el: Element, indent: int, outfh: TextIO) -> bool:
         comma = _extract_child(kid, indent + 4, outfh)
     print(f"\n{ws}{ss}]", end="", file=outfh)
     print(f"\n{ws}}}", end="", file=outfh)
+
     return True
 
 

--- a/playa/cli.py
+++ b/playa/cli.py
@@ -90,7 +90,7 @@ from typing import Any, Deque, Iterable, Iterator, List, TextIO, Tuple, Union
 import playa
 from playa import Document, Page, PDFPasswordIncorrect, asobj
 from playa.data.content import Image
-from playa.data.metadata import asobj_document
+from playa.data.metadata import asobj_document, asobj_structelement
 from playa.image import get_one_image
 from playa.outline import Outline
 from playa.page import ImageObject
@@ -413,7 +413,7 @@ def _extract_element(el: Element, indent: int, outfh: TextIO) -> bool:
     ws = " " * indent
     ss = "  "
 
-    text = json.dumps(asobj(el, recurse=False), indent=2, ensure_ascii=False)
+    text = json.dumps(asobj_structelement(el, recurse=False), indent=2, ensure_ascii=False)
     brace = text.rindex("}")
     print(textwrap.indent(text[:brace].strip(), ws), end="", file=outfh)
     print(f',\n{ws}{ss}"children": [', file=outfh)

--- a/playa/data/metadata.py
+++ b/playa/data/metadata.py
@@ -33,7 +33,6 @@ from playa.pdftypes import (
     matrix_value,
     rect_value,
     resolve1,
-    str_value,
     stream_value,
 )
 from playa.structure import ContentItem as _StructContentItem
@@ -122,6 +121,8 @@ class StructElement(TypedDict, total=False):
 
     type: str
     """Type of structure element (or "StructTreeRoot" for root)."""
+    role: str
+    """Role of structure element (root has no role)."""
     page_idx: int
     """Page on which this structure element's content begins."""
     title: str
@@ -136,6 +137,10 @@ class StructElement(TypedDict, total=False):
     """Unicode text content."""
     children: List["StructElement"]
     """Children of this node."""
+    attributes: dict
+    """Structure attributes."""
+    class_name: str
+    """Structure attribute class name."""
 
 
 class StructTree(TypedDict, total=False):
@@ -610,6 +615,8 @@ def asobj_structelement(obj: _Element, recurse: bool = True) -> StructElement:
         "alternate_description",
         "abbreviation_expansion",
         "actual_text",
+        "attributes",
+        "class_name",
     ):
         val = getattr(obj, attr)
         if val is not None:

--- a/playa/data/metadata.py
+++ b/playa/data/metadata.py
@@ -602,18 +602,20 @@ def asobj_content_object(obj: _StructContentObject) -> StructContentObject:
 def asobj_structelement(obj: _Element, recurse: bool = True) -> StructElement:
     el = StructElement(type=obj.type)
     page = obj.page
+    for attr in (
+        "type",
+        "role",
+        "title",
+        "language",
+        "alternate_description",
+        "abbreviation_expansion",
+        "actual_text",
+    ):
+        val = getattr(obj, attr)
+        if val is not None:
+            el[attr] = asobj(val)
     if page is not None:
         el["page_idx"] = page.page_idx
-    if "T" in obj.props:
-        el["title"] = decode_text(str_value(obj.props["T"]))
-    if "Lang" in obj.props:
-        el["language"] = decode_text(str_value(obj.props["Lang"]))
-    if "Alt" in obj.props:
-        el["alternate_description"] = decode_text(str_value(obj.props["Alt"]))
-    if "E" in obj.props:
-        el["abbreviation_expansion"] = decode_text(str_value(obj.props["E"]))
-    if "ActualText" in obj.props:
-        el["actual_text"] = decode_text(str_value(obj.props["ActualText"]))
     if recurse:
         children = [asobj(el) for el in obj]
         if children:

--- a/playa/document.py
+++ b/playa/document.py
@@ -391,9 +391,14 @@ class Document:
 
         In the case where no logical structure tree exists, this will
         be `None`.  Otherwise you may iterate over it, search it, etc.
-        We do this instead of simply returning an empty structure
-        tree because the vast majority of PDFs have no logical
-        structure.
+
+        We do this instead of simply returning an empty structure tree
+        because the vast majority of PDFs have no logical structure.
+        Also, because the structure is a lazy object (the type
+        signature here may change to `Iterable[Element]` at some
+        point) there is no way to know if it's empty without iterating
+        over it.
+
         """
         if hasattr(self, "_structure"):
             return self._structure

--- a/playa/page.py
+++ b/playa/page.py
@@ -378,11 +378,22 @@ class Page:
         # Elements can contain multiple marked content sections, so
         # don't create redundant Element objects for these
         elements: Dict[int, Element] = {}
-        for obj in parents:
-            objid = obj.objid if isinstance(obj, ObjRef) else id(obj)
-            if objid not in elements:
-                elements[objid] = Element.from_dict(self.doc, dict_value(obj))
-            self._structmap.append(elements[objid])
+        for objref in parents:
+            # It should always be null, or an indirect object reference
+            element: Union[None, Element] = None
+            if objref is None:
+                pass
+            elif isinstance(objref, ObjRef):
+                if objref.objid not in elements:
+                    elements[objref.objid] = Element.from_dict(
+                        self.doc, dict_value(objref)
+                    )
+                element = elements[objref.objid]
+            else:
+                log.warning(
+                    "ParentTree element is not an indirect object reference: %r", objref
+                )
+            self._structmap.append(element)
         return self._structmap
 
     @property

--- a/playa/structure.py
+++ b/playa/structure.py
@@ -31,7 +31,7 @@ from playa.pdftypes import (
     rect_value,
     stream_value,
 )
-from playa.utils import decode_text, transform_bbox, get_bound_rects
+from playa.utils import transform_bbox, get_bound_rects, string_property
 from playa.worker import (
     DocumentRef,
     PageRef,
@@ -431,15 +431,29 @@ class Element(Findable):
             return get_bound_rects(box for box in boxes if box is not BBOX_NONE)
 
     @property
-    def alt(self) -> Union[str, None]:
+    def title(self) -> Union[str, None]:
+        """Title of a structure element."""
+        return string_property(self.props, "T")
+
+    @property
+    def language(self) -> Union[str, None]:
+        """Language code of a structure element."""
+        return string_property(self.props, "Lang")
+
+    @property
+    def alternate_description(self) -> Union[str, None]:
         """Alternate text for a figure element."""
-        if "Alt" not in self.props:
-            return None
-        alttext = resolve1(self.props["Alt"])
-        if not isinstance(alttext, (str, bytes)):
-            LOG.warning("Alt text is not a string: %r", self.props)
-            return None
-        return decode_text(alttext)
+        return string_property(self.props, "Alt")
+
+    @property
+    def abbreviation_expansion(self) -> Union[str, None]:
+        """If element's contents are an abbreviation, the expansion."""
+        return string_property(self.props, "E")
+
+    @property
+    def actual_text(self) -> Union[str, None]:
+        """Replacement text for a structure element."""
+        return string_property(self.props, "ActualText")
 
     def __iter__(self) -> Iterator[Union["Element", ContentItem, ContentObject]]:
         if "K" in self.props:

--- a/playa/structure.py
+++ b/playa/structure.py
@@ -31,7 +31,7 @@ from playa.pdftypes import (
     rect_value,
     stream_value,
 )
-from playa.utils import transform_bbox, get_bound_rects
+from playa.utils import decode_text, transform_bbox, get_bound_rects
 from playa.worker import (
     DocumentRef,
     PageRef,
@@ -436,6 +436,17 @@ class Element(Findable):
                 for item in self.contents
                 if item.page is page and item.bbox is not BBOX_NONE
             )
+
+    @property
+    def alt(self) -> Union[str, None]:
+        """Alternate text for a figure element."""
+        if "Alt" not in self.props:
+            return None
+        alttext = resolve1(self.props["Alt"])
+        if not isinstance(alttext, (str, bytes)):
+            LOG.warning("Alt text is not a string: %r", self.props)
+            return None
+        return decode_text(alttext)
 
     def __iter__(self) -> Iterator[Union["Element", ContentItem, ContentObject]]:
         if "K" in self.props:

--- a/playa/structure.py
+++ b/playa/structure.py
@@ -446,6 +446,12 @@ class Element(Findable):
             kids = resolve1(self.props["K"])
             yield from _make_kids(kids, self.page, self._docref)
 
+    def __hash__(self) -> int:
+        # Ideally we would have an object ID for self.props, but
+        # structure dictionaries are not required to be indirect
+        # objects, so we use their string representation instead
+        return hash((self._docref, repr(self.props)))
+
 
 @functools.singledispatch
 def _make_kids(
@@ -635,7 +641,8 @@ class Tree(Findable):
     page = None
     parent = None
     bbox = BBOX_NONE
-    type = role = "StructTreeRoot"
+    type = "StructTreeRoot"
+    role = "StructTreeRoot"
 
     def __init__(self, doc: "Document") -> None:
         self._docref = _ref_document(doc)

--- a/playa/structure.py
+++ b/playa/structure.py
@@ -622,12 +622,20 @@ class Tree(Findable):
           standard structure types (as strings) (PDF 1.7 section 14.8.4)
       parent_tree: Parent tree linking marked content sections to
           structure elements (PDF 1.7 section 14.7.4.4)
+      parent: A structure tree has no parent element, so this is `None`
+      bbox: A structure tree has no bounding box so this is `BBOX_NONE`
+      type: This is "StructTreeRoot"
+      role: This is also "StructTreeRoot"
     """
 
     _docref: DocumentRef
     props: Dict[str, PDFObject]
     _role_map: Dict[str, str]
     _parent_tree: NumberTree
+    page = None
+    parent = None
+    bbox = BBOX_NONE
+    type = role = "StructTreeRoot"
 
     def __init__(self, doc: "Document") -> None:
         self._docref = _ref_document(doc)
@@ -664,9 +672,10 @@ class Tree(Findable):
         but if you do, here it is.
 
         Unlike the structure tree itself, if there is no parent tree,
-        this will be an empty NumberTree.  This is because the parent
-        tree is required by the spec in the case where structure
-        elements contain marked content, which is nearly all the time.
+        this will be an empty `NumberTree`, not `None`.  This is
+        because the parent tree is required by the spec in the case
+        where structure elements contain marked content, which is
+        nearly all the time.
 
         """
         if hasattr(self, "_parent_tree"):

--- a/playa/utils.py
+++ b/playa/utils.py
@@ -12,7 +12,7 @@ from typing import (
     Union,
 )
 
-from playa.pdftypes import Point, Rect, Matrix
+from playa.pdftypes import PDFObject, Point, Rect, Matrix, dict_value, str_value
 
 
 def paeth_predictor(left: int, above: int, upper_left: int) -> int:
@@ -614,6 +614,28 @@ def decode_text(s: Union[str, bytes]) -> str:
             return "".join(PDFDocEncoding[c] for c in s)
     except IndexError:
         return str(s)
+
+
+def string_property(obj: PDFObject, key: str) -> Union[str, None]:
+    """Retrieve and decode a string property of an object dictionary
+    (such as an annotation, a page, a structure element, etc)
+
+    Takes care of resolving indirect object references in both the
+    object and its values.
+
+    Raises:
+        TypeError: If `obj` is not a dictionary, or if the value
+        requested is not a string
+
+    Returns:
+        The decoded string, or `None` if the property doesn't exist.
+    """
+    objdict = dict_value(obj)
+    val = objdict.get(key)
+    if val is None:
+        return None
+    val = str_value(val)
+    return decode_text(val)
 
 
 ROMAN_ONES = ["i", "x", "c", "m"]

--- a/tests/test_pdftypes.py
+++ b/tests/test_pdftypes.py
@@ -176,29 +176,7 @@ def test_errors() -> None:
         matrix_value((32, "skidoo", 4, 5, 6, 7))  # type: ignore[arg-type]
     broken_image = ContentStream(
         {"ColorSpace": LIT("NotAColorSpace")},
-        rawdata=b"""8 0 obj
-<<
-  /Name /X2
-  /Subtype /Image
-  /BitsPerComponent 8
-  /ColorSpace /DeviceRGB
-  /DecodeParms <</BitsPerComponent 8/Colors 3/Columns 3>>
-  /Filter /ASCIIHexDecode
-  /Type /XObject
-  /StructParent 2
-  /Width 3
-  /Height 5
-  /Length 105
->>
-stream
-AA2222 22AA22 2222AA
-EEEEEE EEEEEE EEEEEE
-AAAAAA AAAAAA AAAAAA
-EEEEEE EEEEEE EEEEEE
-AAAAAA AAAAAA AAAAAA
-endstream
-endobj
-""",
+        rawdata=b"IRRELEVANT!",
     )
     with pytest.raises(ValueError):
         _ = broken_image.colorspace

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -189,5 +189,21 @@ def test_content_structure() -> None:
                 assert obj.parent.role in ("P", "H1", "H2", "H3")
 
 
+def test_element_hash():
+    with playa.open(TESTDIR / "pdf_structure.pdf") as pdf:
+        elements = set(pdf.structure.find_all())
+        page = pdf.pages[0]
+        for element in page.structure:
+            if element is not None:
+                if element.parent is not None:
+                    sibs = set(element.parent)
+                    assert element in sibs
+                    # Make sure that we can test for inequality too
+                    if len(sibs) > 1:
+                        assert sum(1 for sib in sibs if sib == element) < len(sibs)
+                assert element in elements
+                assert element == element
+
+
 if __name__ == "__main__":
     test_specific_structure()

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -205,5 +205,17 @@ def test_element_hash():
                 assert element == element
 
 
+def test_page_structure() -> None:
+    with playa.open(TESTDIR / "pdf_structure.pdf") as pdf:
+        elements = set(pdf.structure.find_all("Table"))
+        assert len(elements) == 1
+        page = pdf.pages[0]
+        count = 0
+        for element in page.structure.find_all("Table"):
+            assert element in elements
+            count += 1
+        assert count == 1
+
+
 if __name__ == "__main__":
     test_specific_structure()

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -207,6 +207,7 @@ def test_element_hash():
 
 def test_page_structure() -> None:
     with playa.open(TESTDIR / "pdf_structure.pdf") as pdf:
+        assert pdf.structure is not None
         elements = set(pdf.structure.find_all("Table"))
         assert len(elements) == 1
         page = pdf.pages[0]
@@ -215,6 +216,8 @@ def test_page_structure() -> None:
             assert element in elements
             count += 1
         assert count == 1
+        assert list(page.structure[0:5].find_all("Table")) == []
+        assert len(list(page.structure[-5:].find_all("Table"))) == 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
By caching marked content sections we get reasonable performance (I might make this Lazier in the future).

We now also return a `PageStructure` instead of a list for `page.structure` and `xobj.structure`, which has convenient methods to search up the parent tree to find enclosing elements (like tables for instance).

Add structure attributes and classes, but note, we don't try to do any overriding or interpretation unlike my ill-considered pdfplumber code.  This does mean that `--structure` in the CLI gets a bit slower as it has more stuff to output.

Also, finally use `asobj` directly in `--structure` in the CLI rather than a custom serializtion.