### PR TITLE
fix: correct and test rotation behaviour which was very broken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## PLAYA 0.7.0: Unreleased
 
 - Remove long-deprecated functions
-- Correct `normalize_rect` (oops!)
 - Add and document `finalize` method on ContentObjects
 - Make `PageList` work more or less like a `Sequence`
 - Support iteration over `playa.structure.ContentItem`
@@ -10,6 +9,11 @@
 - TODO: Add method to complete parent tree for page
 - TODO: Fail fast for incorrect stream lengths
 - TODO: Parse indirect objects with regex
+
+## PLAYA 0.6.6: 2025-08-01
+
+- Correct and test rotation behaviour which was quite incorrect, and
+  also allow users to update rotation and space on an existing page
 
 ## PLAYA 0.6.5: 2025-08-01
 - Fix terrible error in xref detection and parsing

--- a/samples/rotation/0.pdf
+++ b/samples/rotation/0.pdf
@@ -1,0 +1,55 @@
+%PDF-1.4
+1 0 obj
+<<
+ /Type /Catalog
+ /Pages 3 0 R
+>>
+endobj
+3 0 obj
+<<
+ /Type /Pages
+ /Kids [ 4 0 R ]
+ /Count 1
+>>
+endobj
+4 0 obj
+<<
+ /Type /Page
+ /Parent 3 0 R
+ /MediaBox [ 0 0 612 792 ]
+ /Contents 5 0 R
+ /Resources <<
+  /ProcSet 6 0 R
+  /Font << /F1 7 0 R >>
+ >>
+>>
+endobj
+5 0 obj
+<< /Length 44 >>
+stream
+BT
+/F1 24 Tf
+100 700 Td
+(Hello World) Tj
+ET
+endstream
+endobj
+6 0 obj
+[ /PDF /Text ]
+endobj
+7 0 obj
+<<
+ /Type /Font
+ /Subtype /Type1
+ /Name /F1
+ /BaseFont /Helvetica
+ /Encoding /MacRomanEncoding
+>>
+endobj
+
+trailer 
+<<
+ /Size 8
+ /Root 1 0 R
+>>
+%%EOF

--- a/samples/rotation/0mb.pdf
+++ b/samples/rotation/0mb.pdf
@@ -1,0 +1,55 @@
+%PDF-1.4
+1 0 obj
+<<
+ /Type /Catalog
+ /Pages 3 0 R
+>>
+endobj
+3 0 obj
+<<
+ /Type /Pages
+ /Kids [ 4 0 R ]
+ /Count 1
+>>
+endobj
+4 0 obj
+<<
+ /Type /Page
+ /Parent 3 0 R
+ /MediaBox [ 10 20 612 792 ]
+ /Contents 5 0 R
+ /Resources <<
+  /ProcSet 6 0 R
+  /Font << /F1 7 0 R >>
+ >>
+>>
+endobj
+5 0 obj
+<< /Length 44 >>
+stream
+BT
+/F1 24 Tf
+100 700 Td
+(Hello World) Tj
+ET
+endstream
+endobj
+6 0 obj
+[ /PDF /Text ]
+endobj
+7 0 obj
+<<
+ /Type /Font
+ /Subtype /Type1
+ /Name /F1
+ /BaseFont /Helvetica
+ /Encoding /MacRomanEncoding
+>>
+endobj
+
+trailer 
+<<
+ /Size 8
+ /Root 1 0 R
+>>
+%%EOF

--- a/samples/rotation/180.pdf
+++ b/samples/rotation/180.pdf
@@ -1,0 +1,56 @@
+%PDF-1.4
+1 0 obj
+<<
+ /Type /Catalog
+ /Pages 3 0 R
+>>
+endobj
+3 0 obj
+<<
+ /Type /Pages
+ /Kids [ 4 0 R ]
+ /Count 1
+>>
+endobj
+4 0 obj
+<<
+ /Type /Page
+ /Parent 3 0 R
+ /Rotate 180
+ /MediaBox [ 0 0 612 792 ]
+ /Contents 5 0 R
+ /Resources <<
+  /ProcSet 6 0 R
+  /Font << /F1 7 0 R >>
+ >>
+>>
+endobj
+5 0 obj
+<< /Length 44 >>
+stream
+BT
+/F1 24 Tf
+100 700 Td
+(Hello World) Tj
+ET
+endstream
+endobj
+6 0 obj
+[ /PDF /Text ]
+endobj
+7 0 obj
+<<
+ /Type /Font
+ /Subtype /Type1
+ /Name /F1
+ /BaseFont /Helvetica
+ /Encoding /MacRomanEncoding
+>>
+endobj
+
+trailer 
+<<
+ /Size 8
+ /Root 1 0 R
+>>
+%%EOF

--- a/samples/rotation/180mb.pdf
+++ b/samples/rotation/180mb.pdf
@@ -1,0 +1,56 @@
+%PDF-1.4
+1 0 obj
+<<
+ /Type /Catalog
+ /Pages 3 0 R
+>>
+endobj
+3 0 obj
+<<
+ /Type /Pages
+ /Kids [ 4 0 R ]
+ /Count 1
+>>
+endobj
+4 0 obj
+<<
+ /Type /Page
+ /Parent 3 0 R
+ /Rotate 180
+ /MediaBox [ 10 20 612 792 ]
+ /Contents 5 0 R
+ /Resources <<
+  /ProcSet 6 0 R
+  /Font << /F1 7 0 R >>
+ >>
+>>
+endobj
+5 0 obj
+<< /Length 44 >>
+stream
+BT
+/F1 24 Tf
+100 700 Td
+(Hello World) Tj
+ET
+endstream
+endobj
+6 0 obj
+[ /PDF /Text ]
+endobj
+7 0 obj
+<<
+ /Type /Font
+ /Subtype /Type1
+ /Name /F1
+ /BaseFont /Helvetica
+ /Encoding /MacRomanEncoding
+>>
+endobj
+
+trailer 
+<<
+ /Size 8
+ /Root 1 0 R
+>>
+%%EOF

--- a/samples/rotation/270.pdf
+++ b/samples/rotation/270.pdf
@@ -1,0 +1,56 @@
+%PDF-1.4
+1 0 obj
+<<
+ /Type /Catalog
+ /Pages 3 0 R
+>>
+endobj
+3 0 obj
+<<
+ /Type /Pages
+ /Kids [ 4 0 R ]
+ /Count 1
+>>
+endobj
+4 0 obj
+<<
+ /Type /Page
+ /Parent 3 0 R
+ /Rotate 270
+ /MediaBox [ 0 0 612 792 ]
+ /Contents 5 0 R
+ /Resources <<
+  /ProcSet 6 0 R
+  /Font << /F1 7 0 R >>
+ >>
+>>
+endobj
+5 0 obj
+<< /Length 44 >>
+stream
+BT
+/F1 24 Tf
+100 700 Td
+(Hello World) Tj
+ET
+endstream
+endobj
+6 0 obj
+[ /PDF /Text ]
+endobj
+7 0 obj
+<<
+ /Type /Font
+ /Subtype /Type1
+ /Name /F1
+ /BaseFont /Helvetica
+ /Encoding /MacRomanEncoding
+>>
+endobj
+
+trailer 
+<<
+ /Size 8
+ /Root 1 0 R
+>>
+%%EOF

--- a/samples/rotation/270mb.pdf
+++ b/samples/rotation/270mb.pdf
@@ -1,0 +1,56 @@
+%PDF-1.4
+1 0 obj
+<<
+ /Type /Catalog
+ /Pages 3 0 R
+>>
+endobj
+3 0 obj
+<<
+ /Type /Pages
+ /Kids [ 4 0 R ]
+ /Count 1
+>>
+endobj
+4 0 obj
+<<
+ /Type /Page
+ /Parent 3 0 R
+ /Rotate 270
+ /MediaBox [ 10 20 612 792 ]
+ /Contents 5 0 R
+ /Resources <<
+  /ProcSet 6 0 R
+  /Font << /F1 7 0 R >>
+ >>
+>>
+endobj
+5 0 obj
+<< /Length 44 >>
+stream
+BT
+/F1 24 Tf
+100 700 Td
+(Hello World) Tj
+ET
+endstream
+endobj
+6 0 obj
+[ /PDF /Text ]
+endobj
+7 0 obj
+<<
+ /Type /Font
+ /Subtype /Type1
+ /Name /F1
+ /BaseFont /Helvetica
+ /Encoding /MacRomanEncoding
+>>
+endobj
+
+trailer 
+<<
+ /Size 8
+ /Root 1 0 R
+>>
+%%EOF

--- a/samples/rotation/90.pdf
+++ b/samples/rotation/90.pdf
@@ -1,0 +1,56 @@
+%PDF-1.4
+1 0 obj
+<<
+ /Type /Catalog
+ /Pages 3 0 R
+>>
+endobj
+3 0 obj
+<<
+ /Type /Pages
+ /Kids [ 4 0 R ]
+ /Count 1
+>>
+endobj
+4 0 obj
+<<
+ /Type /Page
+ /Parent 3 0 R
+ /Rotate 90
+ /MediaBox [ 0 0 612 792 ]
+ /Contents 5 0 R
+ /Resources <<
+  /ProcSet 6 0 R
+  /Font << /F1 7 0 R >>
+ >>
+>>
+endobj
+5 0 obj
+<< /Length 44 >>
+stream
+BT
+/F1 24 Tf
+100 700 Td
+(Hello World) Tj
+ET
+endstream
+endobj
+6 0 obj
+[ /PDF /Text ]
+endobj
+7 0 obj
+<<
+ /Type /Font
+ /Subtype /Type1
+ /Name /F1
+ /BaseFont /Helvetica
+ /Encoding /MacRomanEncoding
+>>
+endobj
+
+trailer 
+<<
+ /Size 8
+ /Root 1 0 R
+>>
+%%EOF

--- a/samples/rotation/90mb.pdf
+++ b/samples/rotation/90mb.pdf
@@ -1,0 +1,56 @@
+%PDF-1.4
+1 0 obj
+<<
+ /Type /Catalog
+ /Pages 3 0 R
+>>
+endobj
+3 0 obj
+<<
+ /Type /Pages
+ /Kids [ 4 0 R ]
+ /Count 1
+>>
+endobj
+4 0 obj
+<<
+ /Type /Page
+ /Parent 3 0 R
+ /Rotate 90
+ /MediaBox [ 10 20 612 792 ]
+ /Contents 5 0 R
+ /Resources <<
+  /ProcSet 6 0 R
+  /Font << /F1 7 0 R >>
+ >>
+>>
+endobj
+5 0 obj
+<< /Length 44 >>
+stream
+BT
+/F1 24 Tf
+100 700 Td
+(Hello World) Tj
+ET
+endstream
+endobj
+6 0 obj
+[ /PDF /Text ]
+endobj
+7 0 obj
+<<
+ /Type /Font
+ /Subtype /Type1
+ /Name /F1
+ /BaseFont /Helvetica
+ /Encoding /MacRomanEncoding
+>>
+endobj
+
+trailer 
+<<
+ /Size 8
+ /Root 1 0 R
+>>
+%%EOF

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -1,0 +1,60 @@
+"""
+Page-related tests
+"""
+
+import pytest
+
+import playa
+from .data import TESTDIR
+
+
+def test_rotation() -> None:
+    datadir = TESTDIR / "rotation"
+    with playa.open(datadir / "0.pdf") as pdf:
+        hello = next(pdf.pages[0].texts)
+        assert hello.bbox == pytest.approx((100, 74.768, 224.008, 96.968))
+    with playa.open(datadir / "90.pdf") as pdf:
+        hello = next(pdf.pages[0].texts)
+        assert hello.bbox == pytest.approx((792 - 96.968, 100, 792 - 74.768, 224.008))
+    with playa.open(datadir / "180.pdf") as pdf:
+        hello = next(pdf.pages[0].texts)
+        assert hello.bbox == pytest.approx(
+            (612 - 224.008, 792 - 96.968, 612 - 100, 792 - 74.768)
+        )
+    with playa.open(datadir / "270.pdf") as pdf:
+        hello = next(pdf.pages[0].texts)
+        assert hello.bbox == pytest.approx((74.768, 612 - 224.008, 96.968, 612 - 100))
+        # And verify that we can update the rotation
+        pdf.pages[0].set_initial_ctm("screen", 0)
+        hello = next(pdf.pages[0].texts)
+        assert hello.bbox == pytest.approx((100, 74.768, 224.008, 96.968))
+        # And verify that rotation is normalized
+        pdf.pages[0].set_initial_ctm("screen", -90)
+        hello = next(pdf.pages[0].texts)
+        assert hello.bbox == pytest.approx((74.768, 612 - 224.008, 96.968, 612 - 100))
+        
+
+def test_translation() -> None:
+    datadir = TESTDIR / "rotation"
+    with playa.open(datadir / "0mb.pdf") as pdf:
+        hello = next(pdf.pages[0].texts)
+        # screen device space so no effect on Y coords
+        assert hello.bbox == pytest.approx((90, 74.768, 214.008, 96.968))
+    with playa.open(datadir / "0.pdf", space="page") as pdf:
+        hello = next(pdf.pages[0].texts)
+        assert hello.bbox == pytest.approx((100, 695.032, 224.008, 717.232))
+    with playa.open(datadir / "0mb.pdf", space="page") as pdf:
+        hello = next(pdf.pages[0].texts)
+        assert hello.bbox == pytest.approx((90, 675.032, 214.008, 697.232))
+    with playa.open(datadir / "90mb.pdf") as pdf:
+        hello = next(pdf.pages[0].texts)
+        # Just trust me, these are correct
+        assert hello.bbox == pytest.approx((675.032, 90, 697.232, 214.008))
+    with playa.open(datadir / "180mb.pdf") as pdf:
+        hello = next(pdf.pages[0].texts)
+        # Just trust me, these are correct
+        assert hello.bbox == pytest.approx((387.992, 675.032, 512, 697.232))
+    with playa.open(datadir / "270mb.pdf") as pdf:
+        hello = next(pdf.pages[0].texts)
+        # No change here because we cropped the other corner
+        assert hello.bbox == pytest.approx((74.768, 612 - 224.008, 96.968, 612 - 100))


### PR DESCRIPTION
Whoops!  Rotation did something quite wrong in the case of "screen" space or translated MediaBox, because when you rotate, "width" and "height" mean something else for the subsequent space translation.

This may be the actual cause of a long-standing pdfminer.six bug, but it's really my fault for not having done the linear algebra correctly.