### PR TITLE
fix: restore python 3.8 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.8"
       - name: Install Hatch
         uses: pypa/hatch@install
       - name: Run tests
-        run: hatch test --cover -py 3.9 --full-trace
+        run: hatch test --cover -py 3.8 --full-trace

--- a/playa/cmapdb.py
+++ b/playa/cmapdb.py
@@ -9,7 +9,6 @@ More information is available on:
 
 """
 
-import functools
 import gzip
 import logging
 import os
@@ -39,6 +38,14 @@ from playa.parser import (
     literal_name,
 )
 from playa.utils import choplist
+
+try:
+    from functools import cache
+except ImportError:
+    # Simply do not cache when using Python 3.8
+    def cache(func):  # type: ignore
+        return func
+
 
 log = logging.getLogger(__name__)
 
@@ -254,7 +261,7 @@ KEYWORD_ENDNOTDEFRANGE = KWD(b"endnotdefrange")
 
 # These are generally characters or short strings (glyph clusters) so
 # caching them makes sense (they repeat themselves often)
-@functools.cache
+@cache
 def decode_utf16_char(utf16: bytes) -> str:
     return utf16.decode("UTF-16BE", "ignore")
 

--- a/playa/fontprogram.py
+++ b/playa/fontprogram.py
@@ -1567,8 +1567,8 @@ class CFFFontProgram:
 
     def getdict(
         self, data: bytes
-    ) -> Dict[Union[tuple[int, int], int], List[Union[float, int]]]:
-        d: Dict[Union[tuple[int, int], int], List[Union[float, int]]] = {}
+    ) -> Dict[Union[Tuple[int, int], int], List[Union[float, int]]]:
+        d: Dict[Union[Tuple[int, int], int], List[Union[float, int]]] = {}
         fp = BytesIO(data)
         stack: List[Union[float, int]] = []
         while 1:

--- a/playa/page.py
+++ b/playa/page.py
@@ -56,7 +56,7 @@ from playa.worker import PageRef, _deref_document, _deref_page, _ref_document, _
 
 if TYPE_CHECKING:
     from playa.document import Document
-    from playa.structure import Element, PageStructure
+    from playa.structure import PageStructure
 
 log = logging.getLogger(__name__)
 

--- a/playa/worker.py
+++ b/playa/worker.py
@@ -16,7 +16,7 @@ PageRef = Tuple[DocumentRef, int]
 # A global PDF object used in worker processes
 __pdf: Union["Document", None] = None
 # Registry of documents which have workers
-__bosses: weakref.WeakValueDictionary[int, "Document"] = weakref.WeakValueDictionary()
+__bosses: weakref.WeakValueDictionary = weakref.WeakValueDictionary()
 # Numeric id of the document in the boss process (will show up instead
 # of weak references when serialized, gets looked up in _bosses)
 GLOBAL_DOC: int = 0


### PR DESCRIPTION
Whoops!  We weren't actually compatible with Python 3.8 (yes, it is end of life, but since we went to the trouble to use all those old-style type annotations, we might as well keep supporting it!)