### PR TITLE
fix: fail fast on missing fonts (and other objects)

### DIFF
--- a/playa/document.py
+++ b/playa/document.py
@@ -528,9 +528,11 @@ class Document:
                 except PDFSyntaxError as e:
                     log.debug("Syntax error when searching for object %d: %s", objid, e)
                     continue
-            if obj is None:
-                raise IndexError(f"Object with ID {objid} not found")
+            # Store it anyway as None if we can't find it to avoid costly searching
             self._cached_objs[objid] = obj
+        # To get standards compliant behaviour simply remove this
+        if self._cached_objs[objid] is None:
+            raise IndexError(f"Object with ID {objid} not found")
         return self._cached_objs[objid]
 
     def get_font(

--- a/playa/font.py
+++ b/playa/font.py
@@ -181,7 +181,10 @@ class Font:
             (".cff", "FontFile3"),
         ):
             if key in self.descriptor:
-                fontfile = stream_value(self.descriptor[key])
+                fontfile = resolve1(self.descriptor[key])
+                if not isinstance(fontfile, ContentStream):
+                    log.warning("%s is not a content stream", key)
+                    continue
                 fontname = re.sub(r"[^\w\+]", "", self.fontname)
                 outpath = outdir / (fontname + suffix)
                 outpath.write_bytes(fontfile.buffer)


### PR DESCRIPTION
Don't crash if a FontFile (or similar) doesn't exist or is invalid... but also don't DoS either

Notably in one of the pdf.js tests we kept hammering and hammering on a nonexistent indirect object

This should probably fix other such situations too