### PR TITLE
fix: fix tests to test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.10"
       - name: Install Hatch
         uses: pypa/hatch@install
       - name: Run tests
-        run: hatch test -py 3.8 --full-trace
+        run: hatch test --cover

--- a/playa/cli.py
+++ b/playa/cli.py
@@ -687,5 +687,4 @@ def main(argv: Union[List[str], None] = None) -> int:
 
 
 if __name__ == "__main__":
-    import sys
-    sys.exit(main())
+    raise SystemExit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -192,9 +192,8 @@ def test_no_args():
 
 
 def test_bad_page_spec():
-    with pytest.raises(SystemExit):
-        testpdf = str(TESTDIR / "font-size-test.pdf")
-        main(["--pages", "10-4,goodbuddy", "--text", testpdf])
+    testpdf = str(TESTDIR / "font-size-test.pdf")
+    assert main(["--pages", "10-4,goodbuddy", "--text", testpdf]) != 0
 
 
 def test_text_objects():


### PR DESCRIPTION
It seems that hatch will just silently refuse to do anything with Python 3.8 or 3.9 now, which is kind of suboptimal.